### PR TITLE
query_occlusion: firefox number explicit conversion

### DIFF
--- a/samples/query_occlusion.html
+++ b/samples/query_occlusion.html
@@ -101,7 +101,7 @@
         gl.endQuery(gl.ANY_SAMPLES_PASSED);
 
         var samplesPassed = gl.getQueryParameter(query, gl.QUERY_RESULT);
-        document.getElementById('samplesPassed').innerHTML = 'Any samples passed: ' + samplesPassed;
+        document.getElementById('samplesPassed').innerHTML = 'Any samples passed: ' + Number(samplesPassed);
 
         // -- Delete WebGL resources
         gl.deleteBuffer(vertexPosBuffer);


### PR DESCRIPTION
Tiny: FireFox will convert 0/1 to false/true by default, samplesPassed should be explicitly convert to a number. 
