### PR TITLE
Add badge for MIT license

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,11 @@ WebGL 2 Samples Pack
 =====================
 
 [![Build Status](https://travis-ci.org/WebGLSamples/WebGL2Samples.svg?branch=master)](https://travis-ci.org/WebGLSamples/WebGL2Samples)
+[![License](http://img.shields.io/:license-mit-blue.svg)](https://github.com/WebGLSamples/WebGL2Samples/blob/master/LICENSE.md)
 
 Run the live **[WebGL 2 Samples Pack](http://webglsamples.org/WebGL2Samples/)**.
 
 Short and easy to understand samples demonstrating WebGL 2 features by [Shuai Shao (Shrek)](https://shrekshao.github.io) and [Trung Le](http://www.trungtuanle.com/). Advised by [Patrick Cozzi](http://www.seas.upenn.edu/~pcozzi/), University of Pennsylvania.
-
-MIT license.  See [LICENSE.md](LICENSE.md).
 
 ## Samples
 


### PR DESCRIPTION
Adds a nifty badge for the MIT license to the README.md:

![image](https://cloud.githubusercontent.com/assets/782098/12057915/49ecf5c4-af14-11e5-9c29-da65c3320773.png)
