### PR TITLE
transform feedback separated

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Inspired by and ported from Christophe Riccio's ([@Groovounet](https://github.co
 |[sampler_filter](http://webglsamples.org/WebGL2Samples/#sampler_filter)|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 |[texture_integer](http://webglsamples.org/WebGL2Samples/#texture_integer)|:white_check_mark:|:grey_question:|:x: Error: Driver ran out of memory during upload|:grey_question:|
 |[transform_feedback_interleaved](http://webglsamples.org/WebGL2Samples/#transform_feedback_interleaved)|:white_check_mark:|:grey_question:|:white_check_mark:|:grey_question:|
+|[transform_feedback_separated](http://webglsamples.org/WebGL2Samples/#transform_feedback_separated)|:white_check_mark:|:grey_question:|:white_check_mark:|:grey_question:|
 
 ## Running the Samples Locally
 

--- a/index.html
+++ b/index.html
@@ -226,7 +226,8 @@
                 "texture_integer"
             ],
             "Transform Feedback": [
-                "transform_feedback_interleaved"
+                "transform_feedback_interleaved",
+                "transform_feedback_separated"
             ]
         };
 

--- a/samples/transform_feedback_separated.html
+++ b/samples/transform_feedback_separated.html
@@ -14,11 +14,13 @@
 
     <script id="vs-transform" type="x-shader/x-vertex">
         #version 300 es
+        #define POSITION_LOCATION 0
+
         precision highp float;
         precision highp int;
 
         uniform mat4 MVP;
-        layout(location = 0) in vec4 position;
+        layout(location = POSITION_LOCATION) in vec4 position;
 
         out vec4 color;
 
@@ -35,28 +37,32 @@
         precision highp float;
         precision highp int;
 
-        out vec4 color;
+        in vec4 color;
+        out vec4 OColor;
 
         void main()
         {
-            color = vec4(1.0);
+            OColor = color;
         }
     </script>
 
     <script id="vs-feedback" type="x-shader/x-vertex">
         #version 300 es
+        #define POSITION_LOCATION 0
+        #define COLOR_POSITION 3
+
         precision highp float;
         precision highp int;
 
-        layout(location = 0) in vec4 position;
-        layout(location = 1) in vec4 color;
+        layout(location = POSITION_LOCATION) in vec4 position;
+        layout(location = COLOR_POSITION) in vec4 color;
 
-        out vec4 v_color;
+        out vec4 vColor;
 
         void main()
         {
             gl_Position = position;
-            v_color = color;
+            vColor = color;
         }
     </script>
 
@@ -65,13 +71,13 @@
         precision highp float;
         precision highp int;
 
-        in vec4 v_color;
+        in vec4 vColor;
 
         out vec4 color;
 
         void main()
         {
-            color = v_color;
+            color = vColor;
         }
     </script>
 
@@ -98,53 +104,27 @@
             return;
         }
 
+        // -- Init query
+
+        var query = gl.createQuery();
+
         // -- Init Program
-        var PROGRAM_TRANSFORM = 0;
-        var PROGRAM_FEEDBACK = 1;
+        var programTransform = createProgram(gl, getShaderSource('vs-transform'), getShaderSource('fs-transform'));
 
-        var programTransform = (function(gl, vertexShaderSourceTransform, fragmentShaderSourceTransform) {
-            function createShader(gl, source, type) {
-                var shader = gl.createShader(type);
-                gl.shaderSource(shader, source);
-                gl.compileShader(shader);
-                return shader;
-            }
-
-            var vshaderTransform = createShader(gl, vertexShaderSourceTransform, gl.VERTEX_SHADER);
-            var fshaderTransform = createShader(gl, fragmentShaderSourceTransform, gl.FRAGMENT_SHADER);
-
-            var programTransform = gl.createProgram();
-            gl.attachShader(programTransform, vshaderTransform);
-            gl.deleteShader(vshaderTransform);
-            gl.attachShader(programTransform, fshaderTransform);
-            gl.deleteShader(fshaderTransform);
-
-            var strings = ['gl_Position', 'color'];
-            gl.transformFeedbackVaryings(programTransform, strings, gl.SEPARATE_ATTRIBS);
-            gl.linkProgram(programTransform);
-
-            // check
-            var log = gl.getProgramInfoLog(programTransform);
-            if (log) {
-                console.log(log);
-            }
-
-            log = gl.getShaderInfoLog(vshaderTransform);
-            if (log) {
-                console.log(log);
-            }
-
-            return programTransform;
-        })(gl, getShaderSource('vs-transform'), getShaderSource('fs-transform'));
+        var varyings = ['gl_Position', 'color'];
+        gl.transformFeedbackVaryings(programTransform, varyings, gl.SEPARATE_ATTRIBS);
+        gl.linkProgram(programTransform); // Relink program for transform feedback varyings
 
         var programFeedback = createProgram(gl, getShaderSource('vs-feedback'), getShaderSource('fs-feedback'));
 
+        var mvpLocation = gl.getUniformLocation(programTransform, 'MVP');
+
+        var PROGRAM_TRANSFORM = 0;
+        var PROGRAM_FEEDBACK = 1;
         var programs = [programTransform, programFeedback];
 
-        var mvpLocation = gl.getUniformLocation(programs[PROGRAM_TRANSFORM], 'MVP');
-
         // -- Init Buffer
-        var SIZE_V4C4 = 32;
+
         var VERTEX_COUNT = 6;
         var vertices = new Float32Array([
             -1.0, -1.0, 0.0, 1.0,
@@ -155,24 +135,38 @@
             -1.0, -1.0, 0.0, 1.0
         ]);
 
-        var buffers = [gl.createBuffer(), gl.createBuffer()];
+        var BufferType = {
+            VERTEX: 0,
+            POSITION: 1,
+            COLOR: 2,
+            MAX: 3
+        };
+
+        var buffers = new Array(BufferType.MAX);
+        for (var i = 0; i < BufferType.MAX; ++i) {
+            buffers[i] = gl.createBuffer();
+        }
 
         // Transform buffer
-        gl.bindBuffer(gl.ARRAY_BUFFER, buffers[PROGRAM_TRANSFORM]);
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffers[BufferType.VERTEX]);
         gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
         gl.bindBuffer(gl.ARRAY_BUFFER, null);
 
-        // Feedback empty buffer
-        gl.bindBuffer(gl.ARRAY_BUFFER, buffers[PROGRAM_FEEDBACK]);
-        gl.bufferData(gl.ARRAY_BUFFER, SIZE_V4C4 * VERTEX_COUNT, gl.STATIC_COPY);
+        // Feedback empty buffers
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffers[BufferType.POSITION]);
+        gl.bufferData(gl.ARRAY_BUFFER, vertices.length * Float32Array.BYTES_PER_ELEMENT, gl.STATIC_DRAW);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffers[BufferType.COLOR]);
+        gl.bufferData(gl.ARRAY_BUFFER, vertices.length * Float32Array.BYTES_PER_ELEMENT, gl.STATIC_DRAW);
         gl.bindBuffer(gl.ARRAY_BUFFER, null);
 
         // -- Init Vertex Array
         var vertexArrays = [gl.createVertexArray(), gl.createVertexArray()];
         gl.bindVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
 
-        var vertexPosLocation = 0;
-        gl.bindBuffer(gl.ARRAY_BUFFER, buffers[PROGRAM_TRANSFORM]);
+        var vertexPosLocation = 0; // set with GLSL layout qualifier
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffers[BufferType.VERTEX]);
         gl.vertexAttribPointer(vertexPosLocation, 4, gl.FLOAT, false, 0, 0);
         gl.bindBuffer(gl.ARRAY_BUFFER, null);
         gl.enableVertexAttribArray(vertexPosLocation);
@@ -181,56 +175,69 @@
 
         gl.bindVertexArray(vertexArrays[PROGRAM_FEEDBACK]);
 
-        var vertexPosLocationFeedback = 0;
-        var vertexColorLocationFeedback = 1;
-        gl.bindBuffer(gl.ARRAY_BUFFER, buffers[PROGRAM_FEEDBACK]);
-        gl.vertexAttribPointer(vertexPosLocationFeedback, 4, gl.FLOAT, false, SIZE_V4C4, 0);
-        gl.vertexAttribPointer(vertexColorLocationFeedback, 4, gl.FLOAT, false, SIZE_V4C4, SIZE_V4C4 / 2);
-        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+        var vertexPosLocationFeedback = 0; // set with GLSL layout qualifier
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffers[BufferType.POSITION]);
+        gl.vertexAttribPointer(vertexPosLocationFeedback, 4, gl.FLOAT, false, 0, 0);
         gl.enableVertexAttribArray(vertexPosLocationFeedback);
+
+        var vertexColorLocationFeedback = 3; // set with GLSL layout qualifier
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffers[BufferType.COLOR]);
+        gl.vertexAttribPointer(vertexColorLocationFeedback, 4, gl.FLOAT, false, 0, 0);
         gl.enableVertexAttribArray(vertexColorLocationFeedback);
 
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
         gl.bindVertexArray(null);
 
         // -- Render
-        gl.clearColor(0.0, 0.0, 0.0, 1.0);
-        gl.clear(gl.COLOR_BUFFER_BIT);
 
-        // First draw, capture the attributes
-        // Disable rasterization, vertices processing only
-        gl.enable(gl.RASTERIZER_DISCARD);
+        render();
 
-        gl.useProgram(programs[PROGRAM_TRANSFORM]);
-        var matrix = new Float32Array([
-            0.5, 0.0, 0.0, 0.0,
-            0.0, 0.5, 0.0, 0.0,
-            0.0, 0.0, 0.5, 0.0,
-            0.0, 0.0, 0.0, 1.0
-        ]);
-        gl.uniformMatrix4fv(mvpLocation, false, matrix);
+        function render() {
+            gl.clearColor(0.0, 0.0, 0.0, 1.0);
+            gl.clear(gl.COLOR_BUFFER_BIT);
 
-        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, buffers[PROGRAM_FEEDBACK]);
-        gl.bindVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
+            // First draw, capture the attributes
+            // Disable rasterization, vertices processing only
+            gl.enable(gl.RASTERIZER_DISCARD);
 
-        gl.beginTransformFeedback(gl.TRIANGLES);
-        gl.drawArraysInstanced(gl.TRIANGLES, 0, VERTEX_COUNT, 1);
-        gl.endTransformFeedback();
+            gl.useProgram(programs[PROGRAM_TRANSFORM]);
+            var matrix = new Float32Array([
+                0.5, 0.0, 0.0, 0.0,
+                0.0, 0.5, 0.0, 0.0,
+                0.0, 0.0, 0.5, 0.0,
+                0.0, 0.0, 0.0, 1.0
+            ]);
+            gl.uniformMatrix4fv(mvpLocation, false, matrix);
 
-        gl.disable(gl.RASTERIZER_DISCARD);
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, buffers[BufferType.POSITION]);
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, buffers[BufferType.COLOR]);
+            gl.bindVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
 
-        // Second draw, reuse captured attributes
-        gl.useProgram(programs[PROGRAM_FEEDBACK]);
-        gl.bindVertexArray(vertexArrays[PROGRAM_FEEDBACK]);
-        gl.drawArraysInstanced(gl.TRIANGLES, 0, VERTEX_COUNT, 1);
-        gl.bindVertexArray(null);
+            gl.beginQuery(gl.TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, query);
+            gl.beginTransformFeedback(gl.TRIANGLES);
+            gl.drawArraysInstanced(gl.TRIANGLES, 0, VERTEX_COUNT, 1);
+            gl.endTransformFeedback();
+            gl.endQuery(gl.TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN);
 
-        // -- Delete WebGL resources
-        gl.deleteBuffer(buffers[PROGRAM_TRANSFORM]);
-        gl.deleteBuffer(buffers[PROGRAM_FEEDBACK]);
-        gl.deleteProgram(programs[PROGRAM_TRANSFORM]);
-        gl.deleteProgram(programs[PROGRAM_FEEDBACK]);
-        gl.deleteVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
-        gl.deleteVertexArray(vertexArrays[PROGRAM_FEEDBACK]);
+            gl.disable(gl.RASTERIZER_DISCARD);
+
+            // Second draw, reuse captured attributes
+            gl.useProgram(programs[PROGRAM_FEEDBACK]);
+            gl.bindVertexArray(vertexArrays[PROGRAM_FEEDBACK]);
+            gl.drawArraysInstanced(gl.TRIANGLES, 0, VERTEX_COUNT, 1);
+            gl.bindVertexArray(null);
+
+            // -- Delete WebGL resources
+            gl.deleteQuery(query);
+            gl.deleteBuffer(buffers[BufferType.VERTEX]);
+            gl.deleteBuffer(buffers[BufferType.POSITION]);
+            gl.deleteBuffer(buffers[BufferType.COLOR]);
+            gl.deleteProgram(programs[PROGRAM_TRANSFORM]);
+            gl.deleteProgram(programs[PROGRAM_FEEDBACK]);
+            gl.deleteVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
+            gl.deleteVertexArray(vertexArrays[PROGRAM_FEEDBACK]);
+        }
+
     })();
     </script>
 </body>

--- a/samples/transform_feedback_separated.html
+++ b/samples/transform_feedback_separated.html
@@ -104,10 +104,6 @@
             return;
         }
 
-        // -- Init query
-
-        var query = gl.createQuery();
-
         // -- Init Program
         var programTransform = createProgram(gl, getShaderSource('vs-transform'), getShaderSource('fs-transform'));
 
@@ -213,11 +209,9 @@
             gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, buffers[BufferType.COLOR]);
             gl.bindVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
 
-            gl.beginQuery(gl.TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN, query);
             gl.beginTransformFeedback(gl.TRIANGLES);
             gl.drawArraysInstanced(gl.TRIANGLES, 0, VERTEX_COUNT, 1);
             gl.endTransformFeedback();
-            gl.endQuery(gl.TRANSFORM_FEEDBACK_PRIMITIVES_WRITTEN);
 
             gl.disable(gl.RASTERIZER_DISCARD);
 
@@ -228,7 +222,6 @@
             gl.bindVertexArray(null);
 
             // -- Delete WebGL resources
-            gl.deleteQuery(query);
             gl.deleteBuffer(buffers[BufferType.VERTEX]);
             gl.deleteBuffer(buffers[BufferType.POSITION]);
             gl.deleteBuffer(buffers[BufferType.COLOR]);

--- a/samples/transform_feedback_separated.html
+++ b/samples/transform_feedback_separated.html
@@ -22,12 +22,12 @@
         uniform mat4 MVP;
         layout(location = POSITION_LOCATION) in vec4 position;
 
-        out vec4 color;
+        out vec4 v_color;
 
         void main()
         {
             gl_Position = MVP * position;
-            color = vec4(clamp(vec2(position), 0.0, 1.0), 0.0, 1.0);
+            v_color = vec4(clamp(vec2(position), 0.0, 1.0), 0.0, 1.0);
         }
     </script>
 
@@ -37,12 +37,12 @@
         precision highp float;
         precision highp int;
 
-        in vec4 color;
-        out vec4 OColor;
+        in vec4 v_color;
+        out vec4 color;
 
         void main()
         {
-            OColor = color;
+            color = v_color;
         }
     </script>
 
@@ -105,11 +105,40 @@
         }
 
         // -- Init Program
-        var programTransform = createProgram(gl, getShaderSource('vs-transform'), getShaderSource('fs-transform'));
+        var programTransform = (function(gl, vertexShaderSourceTransform, fragmentShaderSourceTransform) {
+            function createShader(gl, source, type) {
+                var shader = gl.createShader(type);
+                gl.shaderSource(shader, source);
+                gl.compileShader(shader);
+                return shader;
+            }
 
-        var varyings = ['gl_Position', 'color'];
-        gl.transformFeedbackVaryings(programTransform, varyings, gl.SEPARATE_ATTRIBS);
-        gl.linkProgram(programTransform); // Relink program for transform feedback varyings
+            var vshaderTransform = createShader(gl, vertexShaderSourceTransform, gl.VERTEX_SHADER);
+            var fshaderTransform = createShader(gl, fragmentShaderSourceTransform, gl.FRAGMENT_SHADER);
+
+            var programTransform = gl.createProgram();
+            gl.attachShader(programTransform, vshaderTransform);
+            gl.deleteShader(vshaderTransform);
+            gl.attachShader(programTransform, fshaderTransform);
+            gl.deleteShader(fshaderTransform);
+
+            var varyings = ['gl_Position', 'v_color'];
+            gl.transformFeedbackVaryings(programTransform, varyings, gl.SEPARATE_ATTRIBS);
+            gl.linkProgram(programTransform);
+
+            // check
+            var log = gl.getProgramInfoLog(programTransform);
+            if (log) {
+                console.log(log);
+            }
+
+            log = gl.getShaderInfoLog(vshaderTransform);
+            if (log) {
+                console.log(log);
+            }
+
+            return programTransform;
+        })(gl, getShaderSource('vs-transform'), getShaderSource('fs-transform'));
 
         var programFeedback = createProgram(gl, getShaderSource('vs-feedback'), getShaderSource('fs-feedback'));
 
@@ -122,7 +151,7 @@
         // -- Init Buffer
 
         var VERTEX_COUNT = 6;
-        var vertices = new Float32Array([
+        var positions = new Float32Array([
             -1.0, -1.0, 0.0, 1.0,
              1.0, -1.0, 0.0, 1.0,
              1.0, 1.0, 0.0, 1.0,
@@ -145,16 +174,16 @@
 
         // Transform buffer
         gl.bindBuffer(gl.ARRAY_BUFFER, buffers[BufferType.VERTEX]);
-        gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
+        gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
         gl.bindBuffer(gl.ARRAY_BUFFER, null);
 
         // Feedback empty buffers
         gl.bindBuffer(gl.ARRAY_BUFFER, buffers[BufferType.POSITION]);
-        gl.bufferData(gl.ARRAY_BUFFER, vertices.length * Float32Array.BYTES_PER_ELEMENT, gl.STATIC_DRAW);
+        gl.bufferData(gl.ARRAY_BUFFER, positions.length * Float32Array.BYTES_PER_ELEMENT, gl.STATIC_DRAW);
         gl.bindBuffer(gl.ARRAY_BUFFER, null);
 
         gl.bindBuffer(gl.ARRAY_BUFFER, buffers[BufferType.COLOR]);
-        gl.bufferData(gl.ARRAY_BUFFER, vertices.length * Float32Array.BYTES_PER_ELEMENT, gl.STATIC_DRAW);
+        gl.bufferData(gl.ARRAY_BUFFER, positions.length * Float32Array.BYTES_PER_ELEMENT, gl.STATIC_DRAW);
         gl.bindBuffer(gl.ARRAY_BUFFER, null);
 
         // -- Init Vertex Array
@@ -186,50 +215,46 @@
 
         // -- Render
 
-        render();
+        gl.clearColor(0.0, 0.0, 0.0, 1.0);
+        gl.clear(gl.COLOR_BUFFER_BIT);
 
-        function render() {
-            gl.clearColor(0.0, 0.0, 0.0, 1.0);
-            gl.clear(gl.COLOR_BUFFER_BIT);
+        // First draw, capture the attributes
+        // Disable rasterization, vertices processing only
+        gl.enable(gl.RASTERIZER_DISCARD);
 
-            // First draw, capture the attributes
-            // Disable rasterization, vertices processing only
-            gl.enable(gl.RASTERIZER_DISCARD);
+        gl.useProgram(programs[PROGRAM_TRANSFORM]);
+        var matrix = new Float32Array([
+            0.5, 0.0, 0.0, 0.0,
+            0.0, 0.5, 0.0, 0.0,
+            0.0, 0.0, 0.5, 0.0,
+            0.0, 0.0, 0.0, 1.0
+        ]);
+        gl.uniformMatrix4fv(mvpLocation, false, matrix);
 
-            gl.useProgram(programs[PROGRAM_TRANSFORM]);
-            var matrix = new Float32Array([
-                0.5, 0.0, 0.0, 0.0,
-                0.0, 0.5, 0.0, 0.0,
-                0.0, 0.0, 0.5, 0.0,
-                0.0, 0.0, 0.0, 1.0
-            ]);
-            gl.uniformMatrix4fv(mvpLocation, false, matrix);
+        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, buffers[BufferType.POSITION]);
+        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, buffers[BufferType.COLOR]);
+        gl.bindVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
 
-            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, buffers[BufferType.POSITION]);
-            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, buffers[BufferType.COLOR]);
-            gl.bindVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
+        gl.beginTransformFeedback(gl.TRIANGLES);
+        gl.drawArraysInstanced(gl.TRIANGLES, 0, VERTEX_COUNT, 1);
+        gl.endTransformFeedback();
 
-            gl.beginTransformFeedback(gl.TRIANGLES);
-            gl.drawArraysInstanced(gl.TRIANGLES, 0, VERTEX_COUNT, 1);
-            gl.endTransformFeedback();
+        gl.disable(gl.RASTERIZER_DISCARD);
 
-            gl.disable(gl.RASTERIZER_DISCARD);
+        // Second draw, reuse captured attributes
+        gl.useProgram(programs[PROGRAM_FEEDBACK]);
+        gl.bindVertexArray(vertexArrays[PROGRAM_FEEDBACK]);
+        gl.drawArraysInstanced(gl.TRIANGLES, 0, VERTEX_COUNT, 1);
+        gl.bindVertexArray(null);
 
-            // Second draw, reuse captured attributes
-            gl.useProgram(programs[PROGRAM_FEEDBACK]);
-            gl.bindVertexArray(vertexArrays[PROGRAM_FEEDBACK]);
-            gl.drawArraysInstanced(gl.TRIANGLES, 0, VERTEX_COUNT, 1);
-            gl.bindVertexArray(null);
-
-            // -- Delete WebGL resources
-            gl.deleteBuffer(buffers[BufferType.VERTEX]);
-            gl.deleteBuffer(buffers[BufferType.POSITION]);
-            gl.deleteBuffer(buffers[BufferType.COLOR]);
-            gl.deleteProgram(programs[PROGRAM_TRANSFORM]);
-            gl.deleteProgram(programs[PROGRAM_FEEDBACK]);
-            gl.deleteVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
-            gl.deleteVertexArray(vertexArrays[PROGRAM_FEEDBACK]);
-        }
+        // -- Delete WebGL resources
+        gl.deleteBuffer(buffers[BufferType.VERTEX]);
+        gl.deleteBuffer(buffers[BufferType.POSITION]);
+        gl.deleteBuffer(buffers[BufferType.COLOR]);
+        gl.deleteProgram(programs[PROGRAM_TRANSFORM]);
+        gl.deleteProgram(programs[PROGRAM_FEEDBACK]);
+        gl.deleteVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
+        gl.deleteVertexArray(vertexArrays[PROGRAM_FEEDBACK]);
 
     })();
     </script>

--- a/samples/transform_feedback_separated.html
+++ b/samples/transform_feedback_separated.html
@@ -1,0 +1,237 @@
+<!DOCTYPE html>
+<!-- Ported from the OpenGL Samples Pack: https://github.com/g-truc/ogl-samples/blob/master/tests/gl-320-transform-feedback-separated.cpp -->
+<html lang="en">
+
+<head>
+    <title>WebGL 2 Samples - transform_feedback_separated</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+    <div id="info">WebGL 2 Samples - transform_feedback_separated</div>
+
+    <script id="vs-transform" type="x-shader/x-vertex">
+        #version 300 es
+        precision highp float;
+        precision highp int;
+
+        uniform mat4 MVP;
+        layout(location = 0) in vec4 position;
+
+        out vec4 color;
+
+        void main()
+        {
+            gl_Position = MVP * position;
+            color = vec4(clamp(vec2(position), 0.0, 1.0), 0.0, 1.0);
+        }
+    </script>
+
+    <!-- This fragment shader will not be called since it is used when the rasterizer is disabled. -->
+    <script id="fs-transform" type="x-shader/x-fragment">
+        #version 300 es
+        precision highp float;
+        precision highp int;
+
+        out vec4 color;
+
+        void main()
+        {
+            color = vec4(1.0);
+        }
+    </script>
+
+    <script id="vs-feedback" type="x-shader/x-vertex">
+        #version 300 es
+        precision highp float;
+        precision highp int;
+
+        layout(location = 0) in vec4 position;
+        layout(location = 1) in vec4 color;
+
+        out vec4 v_color;
+
+        void main()
+        {
+            gl_Position = position;
+            v_color = color;
+        }
+    </script>
+
+    <script id="fs-feedback" type="x-shader/x-fragment">
+        #version 300 es
+        precision highp float;
+        precision highp int;
+
+        in vec4 v_color;
+
+        out vec4 color;
+
+        void main()
+        {
+            color = v_color;
+        }
+    </script>
+
+    <script src="utility.js"></script>
+    <script>
+    (function () {
+        'use strict';
+
+        // -- Init Canvas
+        var canvas = document.createElement('canvas');
+        canvas.width = Math.min(window.innerWidth, window.innerHeight);
+        canvas.height = canvas.width;
+        document.body.appendChild(canvas);
+
+        // -- Init WebGL Context
+        var gl = canvas.getContext('webgl2', { antialias: false });
+        if (!gl) {
+            gl = canvas.getContext('experimental-webgl2', { antialias: false });
+        }
+        var isWebGL2 = !!gl;
+        if(!isWebGL2)
+        {
+            document.getElementById('info').innerHTML = 'WebGL 2 is not available.  See <a href="https://www.khronos.org/webgl/wiki/Getting_a_WebGL_Implementation">How to get a WebGL 2 implementation</a>';
+            return;
+        }
+
+        // -- Init Program
+        var PROGRAM_TRANSFORM = 0;
+        var PROGRAM_FEEDBACK = 1;
+
+        var programTransform = (function(gl, vertexShaderSourceTransform, fragmentShaderSourceTransform) {
+            function createShader(gl, source, type) {
+                var shader = gl.createShader(type);
+                gl.shaderSource(shader, source);
+                gl.compileShader(shader);
+                return shader;
+            }
+
+            var vshaderTransform = createShader(gl, vertexShaderSourceTransform, gl.VERTEX_SHADER);
+            var fshaderTransform = createShader(gl, fragmentShaderSourceTransform, gl.FRAGMENT_SHADER);
+
+            var programTransform = gl.createProgram();
+            gl.attachShader(programTransform, vshaderTransform);
+            gl.deleteShader(vshaderTransform);
+            gl.attachShader(programTransform, fshaderTransform);
+            gl.deleteShader(fshaderTransform);
+
+            var strings = ['gl_Position', 'color'];
+            gl.transformFeedbackVaryings(programTransform, strings, gl.SEPARATE_ATTRIBS);
+            gl.linkProgram(programTransform);
+
+            // check
+            var log = gl.getProgramInfoLog(programTransform);
+            if (log) {
+                console.log(log);
+            }
+
+            log = gl.getShaderInfoLog(vshaderTransform);
+            if (log) {
+                console.log(log);
+            }
+
+            return programTransform;
+        })(gl, getShaderSource('vs-transform'), getShaderSource('fs-transform'));
+
+        var programFeedback = createProgram(gl, getShaderSource('vs-feedback'), getShaderSource('fs-feedback'));
+
+        var programs = [programTransform, programFeedback];
+
+        var mvpLocation = gl.getUniformLocation(programs[PROGRAM_TRANSFORM], 'MVP');
+
+        // -- Init Buffer
+        var SIZE_V4C4 = 32;
+        var VERTEX_COUNT = 6;
+        var vertices = new Float32Array([
+            -1.0, -1.0, 0.0, 1.0,
+             1.0, -1.0, 0.0, 1.0,
+             1.0, 1.0, 0.0, 1.0,
+             1.0, 1.0, 0.0, 1.0,
+            -1.0, 1.0, 0.0, 1.0,
+            -1.0, -1.0, 0.0, 1.0
+        ]);
+
+        var buffers = [gl.createBuffer(), gl.createBuffer()];
+
+        // Transform buffer
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffers[PROGRAM_TRANSFORM]);
+        gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+        // Feedback empty buffer
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffers[PROGRAM_FEEDBACK]);
+        gl.bufferData(gl.ARRAY_BUFFER, SIZE_V4C4 * VERTEX_COUNT, gl.STATIC_COPY);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+        // -- Init Vertex Array
+        var vertexArrays = [gl.createVertexArray(), gl.createVertexArray()];
+        gl.bindVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
+
+        var vertexPosLocation = 0;
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffers[PROGRAM_TRANSFORM]);
+        gl.vertexAttribPointer(vertexPosLocation, 4, gl.FLOAT, false, 0, 0);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+        gl.enableVertexAttribArray(vertexPosLocation);
+
+        gl.bindVertexArray(null);
+
+        gl.bindVertexArray(vertexArrays[PROGRAM_FEEDBACK]);
+
+        var vertexPosLocationFeedback = 0;
+        var vertexColorLocationFeedback = 1;
+        gl.bindBuffer(gl.ARRAY_BUFFER, buffers[PROGRAM_FEEDBACK]);
+        gl.vertexAttribPointer(vertexPosLocationFeedback, 4, gl.FLOAT, false, SIZE_V4C4, 0);
+        gl.vertexAttribPointer(vertexColorLocationFeedback, 4, gl.FLOAT, false, SIZE_V4C4, SIZE_V4C4 / 2);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+        gl.enableVertexAttribArray(vertexPosLocationFeedback);
+        gl.enableVertexAttribArray(vertexColorLocationFeedback);
+
+        gl.bindVertexArray(null);
+
+        // -- Render
+        gl.clearColor(0.0, 0.0, 0.0, 1.0);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+
+        // First draw, capture the attributes
+        // Disable rasterization, vertices processing only
+        gl.enable(gl.RASTERIZER_DISCARD);
+
+        gl.useProgram(programs[PROGRAM_TRANSFORM]);
+        var matrix = new Float32Array([
+            0.5, 0.0, 0.0, 0.0,
+            0.0, 0.5, 0.0, 0.0,
+            0.0, 0.0, 0.5, 0.0,
+            0.0, 0.0, 0.0, 1.0
+        ]);
+        gl.uniformMatrix4fv(mvpLocation, false, matrix);
+
+        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, buffers[PROGRAM_FEEDBACK]);
+        gl.bindVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
+
+        gl.beginTransformFeedback(gl.TRIANGLES);
+        gl.drawArraysInstanced(gl.TRIANGLES, 0, VERTEX_COUNT, 1);
+        gl.endTransformFeedback();
+
+        gl.disable(gl.RASTERIZER_DISCARD);
+
+        // Second draw, reuse captured attributes
+        gl.useProgram(programs[PROGRAM_FEEDBACK]);
+        gl.bindVertexArray(vertexArrays[PROGRAM_FEEDBACK]);
+        gl.drawArraysInstanced(gl.TRIANGLES, 0, VERTEX_COUNT, 1);
+        gl.bindVertexArray(null);
+
+        // -- Delete WebGL resources
+        gl.deleteBuffer(buffers[PROGRAM_TRANSFORM]);
+        gl.deleteBuffer(buffers[PROGRAM_FEEDBACK]);
+        gl.deleteProgram(programs[PROGRAM_TRANSFORM]);
+        gl.deleteProgram(programs[PROGRAM_FEEDBACK]);
+        gl.deleteVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
+        gl.deleteVertexArray(vertexArrays[PROGRAM_FEEDBACK]);
+    })();
+    </script>
+</body>
+</html>

--- a/samples/transform_feedback_separated.html
+++ b/samples/transform_feedback_separated.html
@@ -57,12 +57,12 @@
         layout(location = POSITION_LOCATION) in vec4 position;
         layout(location = COLOR_POSITION) in vec4 color;
 
-        out vec4 vColor;
+        out vec4 v_color;
 
         void main()
         {
             gl_Position = position;
-            vColor = color;
+            v_color = color;
         }
     </script>
 
@@ -71,13 +71,13 @@
         precision highp float;
         precision highp int;
 
-        in vec4 vColor;
+        in vec4 v_color;
 
         out vec4 color;
 
         void main()
         {
-            color = vColor;
+            color = v_color;
         }
     </script>
 
@@ -94,9 +94,6 @@
 
         // -- Init WebGL Context
         var gl = canvas.getContext('webgl2', { antialias: false });
-        if (!gl) {
-            gl = canvas.getContext('experimental-webgl2', { antialias: false });
-        }
         var isWebGL2 = !!gl;
         if(!isWebGL2)
         {
@@ -255,7 +252,6 @@
         gl.deleteProgram(programs[PROGRAM_FEEDBACK]);
         gl.deleteVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
         gl.deleteVertexArray(vertexArrays[PROGRAM_FEEDBACK]);
-
     })();
     </script>
 </body>


### PR DESCRIPTION
@shrekshao @pjcozzi Ready for review. I didn't use a query to get the TRANSFORM_FEEDBACK_PRIMITIVES in the 2nd draw pass since WebGL2 can only get the query's result asynchronously. I opted to just hardcoded the VERTEX_COUNT length instead. 
