### PR TITLE
texture_immutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Inspired by and ported from Christophe Riccio's ([@Groovounet](https://github.co
 |[texture_format](http://webglsamples.org/WebGL2Samples/#texture_format)|:grey_question:|:white_check_mark:|:grey_question:|:white_check_mark:|
 |[texture_fetch](http://webglsamples.org/WebGL2Samples/#texture_fetch)|:white_check_mark:|:grey_question:|:white_check_mark:|:grey_question:|
 |[texture_3d](http://webglsamples.org/WebGL2Samples/#texture_3d)|:white_check_mark:|:white_check_mark:|:grey_question:|:white_check_mark:|
-|[texture_immutable](http://webglsamples.org/WebGL2Samples/#texture_immutable)|:grey_question:|:white_check_mark: Need to update for texStorage3D|:grey_question:|:white_check_mark:Need to update for texStorage3D|
+|[texture_immutable](http://webglsamples.org/WebGL2Samples/#texture_immutable)|:grey_question:|:white_check_mark: Need to update for texStorage3D|:grey_question:|:white_check_mark:|
 |[texture_integer](http://webglsamples.org/WebGL2Samples/#texture_integer)|:white_check_mark:|:grey_question:|:x: Error: Driver ran out of memory during upload|:grey_question:|
 |[texture_lod](http://webglsamples.org/WebGL2Samples/#texture_lod)|:white_check_mark:|:grey_question:|:white_check_mark:|:grey_question:|
 |[texture_offset](http://webglsamples.org/WebGL2Samples/#texture_offset)|:grey_question:|:white_check_mark:|:grey_question:|:white_check_mark:|

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Inspired by and ported from Christophe Riccio's ([@Groovounet](https://github.co
 |[texture_format](http://webglsamples.org/WebGL2Samples/#texture_format)|:grey_question:|:white_check_mark:|:grey_question:|:white_check_mark:|
 |[texture_fetch](http://webglsamples.org/WebGL2Samples/#texture_fetch)|:white_check_mark:|:grey_question:|:white_check_mark:|:grey_question:|
 |[texture_3d](http://webglsamples.org/WebGL2Samples/#texture_3d)|:white_check_mark:|:white_check_mark:|:grey_question:|:white_check_mark:|
+|[texture_immutable](http://webglsamples.org/WebGL2Samples/#texture_immutable)|:grey_question:|:white_check_mark: Need to update for texStorage3D|:grey_question:|:white_check_mark:Need to update for texStorage3D|
 |[texture_integer](http://webglsamples.org/WebGL2Samples/#texture_integer)|:white_check_mark:|:grey_question:|:x: Error: Driver ran out of memory during upload|:grey_question:|
 |[texture_lod](http://webglsamples.org/WebGL2Samples/#texture_lod)|:white_check_mark:|:grey_question:|:white_check_mark:|:grey_question:|
 |[texture_offset](http://webglsamples.org/WebGL2Samples/#texture_offset)|:grey_question:|:white_check_mark:|:grey_question:|:white_check_mark:|

--- a/index.html
+++ b/index.html
@@ -232,6 +232,7 @@
                 "texture_3d",
                 "texture_fetch",
                 "texture_format",
+                "texture_immutable",
                 "texture_integer",
                 "texture_lod",
                 "texture_offset",

--- a/samples/style.css
+++ b/samples/style.css
@@ -15,6 +15,13 @@ body {
     padding: 5px;
 }
 
+#description {
+    position: absolute;
+    top: 20px;
+    width: 100%;
+    padding: 5px;
+}
+
 a {
     color: #0080ff;
 }

--- a/samples/texture_immutable.html
+++ b/samples/texture_immutable.html
@@ -15,7 +15,7 @@
 
 <body>
     <div id="info">WebGL 2 Samples - texture_immutable</div>
-    <div id="description">Immutable texture refers to the texture's allocation, not the content of the texture. Therefore, new pixel data can be uploaded, but not the size of the texture storage</div>
+    <p id="description">Immutable texture refers to the texture's allocation, not the content of the texture. Therefore, new pixel data can be uploaded, but not the size of the texture storage</p>
 
     <!-- WebGL 2 shaders -->
     <script id="vs" type="x-shader/x-vertex">
@@ -236,7 +236,7 @@
 
             // Immutable 3D texture
             gl.useProgram(program3D);
-            gl.uniform1i(diffuseLocation3D, 0);
+            gl.uniform1i(diffuseLocation3D, 1);
 
             gl.activeTexture(gl.TEXTURE1);
             // @todo: fix context lost error for 3D storage
@@ -271,16 +271,16 @@
             gl.bindTexture(gl.TEXTURE_3D, texture3D);
             gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_BASE_LEVEL, 0);
             gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MAX_LEVEL, Math.log2(SIZE));
-            gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
-            gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+            gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MIN_FILTER, gl.NEAREST_MIPMAP_NEAREST);
+            gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
 
             gl.texStorage3D(
-                gl.TEXTURE_3D,  // target
-                Math.log2(SIZE),              // levels
-                gl.R32F,        // internalformat
-                SIZE,           // width
-                SIZE,           // height
-                SIZE            // depth
+                gl.TEXTURE_3D,   // target
+                Math.log2(SIZE), // levels
+                gl.R32F,         // internalformat
+                SIZE,            // width
+                SIZE,            // height
+                SIZE             // depth
                 );
 
             gl.texSubImage3D(

--- a/samples/texture_immutable.html
+++ b/samples/texture_immutable.html
@@ -1,0 +1,309 @@
+<!DOCTYPE html>
+
+<html lang="en">
+
+<head>
+    <title>WebGL 2 Samples - texture_immutable</title>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
+    <link rel="stylesheet" href="style.css">
+    <script src="third-party/gl-matrix.js"></script>
+    <script src="third-party/noise3D.js"></script>
+    <script src="utility.js"></script>
+
+</head>
+
+<body>
+    <div id="info">WebGL 2 Samples - texture_immutable</div>
+    <div id="description">Immutable texture refers to the texture's allocation, not the content of the texture. Therefore, new pixel data can be uploaded, but not the size of the texture storage</div>
+
+    <!-- WebGL 2 shaders -->
+    <script id="vs" type="x-shader/x-vertex">
+        #version 300 es
+        precision highp float;
+        precision highp int;
+
+        uniform mat4 MVP;
+
+        layout(location = 0) in vec2 position;
+        layout(location = 1) in vec2 texcoord;
+
+        out vec2 st;
+
+        void main()
+        {
+            st = texcoord;
+            gl_Position = MVP * vec4(position, 0.0, 1.0);
+        }
+    </script>
+
+    <script id="fs" type="x-shader/x-fragment">
+        #version 300 es
+        precision highp float;
+        precision highp int;
+
+        uniform sampler2D diffuse;
+
+        in vec2 st;
+
+        out vec4 color;
+
+        void main()
+        {
+            color = texture(diffuse, st);
+        }
+    </script>
+
+    <script id="vs-3d" type="x-shader/x-vertex">
+        #version 300 es
+        #define POSITION_LOCATION 0
+        #define TEXCOORD_LOCATION 1
+
+        precision highp float;
+        precision highp int;
+
+        layout(location = POSITION_LOCATION) in vec2 position;
+        layout(location = TEXCOORD_LOCATION) in vec2 in_texcoord;
+
+        // Output 3D texture coordinate after transformation
+        out vec3 texcoord;
+
+        void main()
+        {
+            // Multiply the texture coordinate by the transformation
+            // matrix to place it into 3D space
+            texcoord = (mat4(1.0) * vec4(in_texcoord - vec2(0.5, 0.5), 0.5, 1.0)).stp;
+            gl_Position = vec4(position, 0.0, 1.0);
+        }
+
+    </script>
+
+    <script id="fs-3d" type="x-shader/x-fragment">
+        #version 300 es
+
+        precision highp float;
+        precision highp int;
+        precision highp sampler3D;
+
+        uniform sampler3D diffuse;
+
+        in vec3 texcoord;
+
+        out vec4 color;
+
+        void main()
+        {
+            color = texture(diffuse, texcoord);
+        }
+    </script>
+
+    <script>
+    (function () {
+        'use strict';
+
+        var canvas = document.createElement('canvas');
+        canvas.width = Math.min(window.innerWidth, window.innerHeight);
+        canvas.height = canvas.width;
+        document.body.appendChild(canvas);
+
+        var gl = canvas.getContext( 'webgl2', { antialias: false } );
+        var isWebGL2 = !!gl;
+        if(!isWebGL2)
+        {
+            document.getElementById('info').innerHTML = 'WebGL 2 is not available.  See <a href="https://www.khronos.org/webgl/wiki/Getting_a_WebGL_Implementation">How to get a WebGL 2 implementation</a>';
+            return;
+        }
+
+        var Corners = {
+            LEFT: 0,
+            RIGHT: 1,
+            MAX: 2
+        };
+
+        var viewports = new Array(Corners.MAX);
+
+        viewports[Corners.LEFT] = {
+            x: 0,
+            y: canvas.height / 4,
+            z: canvas.width / 2,
+            w: canvas.height / 2
+        };
+
+        viewports[Corners.RIGHT] = {
+            x: canvas.width / 2,
+            y: canvas.height / 4,
+            z: canvas.width / 2,
+            w: canvas.height / 2
+        };
+
+        // -- Init program
+        var program = createProgram(gl, getShaderSource('vs'), getShaderSource('fs'));
+        var mvpLocation = gl.getUniformLocation(program, 'MVP');
+        var diffuseLocation = gl.getUniformLocation(program, 'diffuse');
+
+        var program3D = createProgram(gl, getShaderSource('vs-3d'), getShaderSource('fs-3d'));
+        var diffuseLocation3D = gl.getUniformLocation(program3D, 'diffuse');
+
+        // -- Init buffers: vec2 Position, vec2 Texcoord
+        var positions = new Float32Array([
+            -1.0, -1.0,
+             1.0, -1.0,
+             1.0,  1.0,
+             1.0,  1.0,
+            -1.0,  1.0,
+            -1.0, -1.0
+        ]);
+        var vertexPosBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, vertexPosBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, positions, gl.STATIC_DRAW);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+        var texCoords = new Float32Array([
+            0.0, 1.0,
+            1.0, 1.0,
+            1.0, 0.0,
+            1.0, 0.0,
+            0.0, 0.0,
+            0.0, 1.0
+        ]);
+        var vertexTexBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, vertexTexBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, texCoords, gl.STATIC_DRAW);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+        // -- Init VertexArray
+        var vertexArray = gl.createVertexArray();
+        gl.bindVertexArray(vertexArray);
+
+        var vertexPosLocation = 0; // set with GLSL layout qualifier
+        gl.enableVertexAttribArray(vertexPosLocation);
+        gl.bindBuffer(gl.ARRAY_BUFFER, vertexPosBuffer);
+        gl.vertexAttribPointer(vertexPosLocation, 2, gl.FLOAT, false, 0, 0);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+        var vertexTexLocation = 1; // set with GLSL layout qualifier
+        gl.enableVertexAttribArray(vertexTexLocation);
+        gl.bindBuffer(gl.ARRAY_BUFFER, vertexTexBuffer);
+        gl.vertexAttribPointer(vertexTexLocation, 2, gl.FLOAT, false, 0, 0);
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
+
+        gl.bindVertexArray(null);
+
+        // -- Init 3D texture
+        // @todo: fix context lost error for 3D storage
+        // var texture3D = create3DTexture();
+
+        // -- Initialize 3D texture data
+
+        var imageUrl = '../assets/img/Di-3d.png';
+        loadImage(imageUrl, function(image) {
+            // -- Init 2D Texture
+            var texture2D = gl.createTexture();
+            gl.activeTexture(gl.TEXTURE1);
+            gl.bindTexture(gl.TEXTURE_2D, texture2D);
+            gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, false);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.NEAREST);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.NEAREST);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+            gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+
+            // -- Allocate storage for the texture
+            gl.texStorage2D(gl.TEXTURE_2D, 1, gl.RGB8, 512, 512);
+            gl.texSubImage2D(gl.TEXTURE_2D, 0, 0, 0, gl.RGB, gl.UNSIGNED_BYTE, image);
+
+            // -- Render
+            gl.clearColor(0.0, 0.0, 0.0, 1.0);
+            gl.clear(gl.COLOR_BUFFER_BIT);
+
+            gl.bindVertexArray(vertexArray);
+
+            var matrix = new Float32Array([
+                1.0, 0.0, 0.0, 0.0,
+                0.0, 1.0, 0.0, 0.0,
+                0.0, 0.0, 1.0, 0.0,
+                0.0, 0.0, 0.0, 1.0
+            ]);
+
+            // Immutable 2D texture
+            gl.useProgram(program);
+            gl.uniformMatrix4fv(mvpLocation, false, matrix);
+            gl.uniform1i(diffuseLocation, 0);
+
+            gl.activeTexture(gl.TEXTURE0);
+            gl.bindTexture(gl.TEXTURE_2D, texture2D);
+            gl.viewport(viewports[Corners.LEFT].x, viewports[Corners.LEFT].y, viewports[Corners.LEFT].z, viewports[Corners.LEFT].w);
+            gl.drawArrays(gl.TRIANGLES, 0, 6);
+
+            // Immutable 3D texture
+            gl.useProgram(program3D);
+            gl.uniform1i(diffuseLocation3D, 0);
+
+            gl.activeTexture(gl.TEXTURE1);
+            // @todo: fix context lost error for 3D storage
+            // gl.bindTexture(gl.TEXTURE_3D, texture3D);
+            gl.viewport(viewports[Corners.RIGHT].x, viewports[Corners.RIGHT].y, viewports[Corners.RIGHT].z, viewports[Corners.RIGHT].w);
+            gl.drawArrays(gl.TRIANGLES, 0, 6);
+
+            // Delete WebGL resources
+            gl.deleteBuffer(vertexPosBuffer);
+            gl.deleteBuffer(vertexTexBuffer);
+            gl.deleteTexture(texture2D);
+            // @todo: fix context lost error for 3D storage
+            // gl.deleteTexture(texture3D);
+            gl.deleteProgram(program);
+            gl.deleteProgram(program3D);
+            gl.deleteVertexArray(vertexArray);
+        });
+
+        function create3DTexture() {
+            var SIZE = 32;
+            var data = new Float32Array(SIZE * SIZE * SIZE);
+            for (var k = 0; k < SIZE; ++k) {
+                for (var j = 0; j < SIZE; ++j) {
+                    for (var i = 0; i < SIZE; ++i) {
+                        data[i + j * SIZE + k * SIZE * SIZE] = snoise([i, j, k]);
+                    }
+                }
+            }
+
+            var texture3D = gl.createTexture();
+            gl.activeTexture(gl.TEXTURE1);
+            gl.bindTexture(gl.TEXTURE_3D, texture3D);
+            gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_BASE_LEVEL, 0);
+            gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MAX_LEVEL, Math.log2(SIZE));
+            gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MIN_FILTER, gl.LINEAR_MIPMAP_LINEAR);
+            gl.texParameteri(gl.TEXTURE_3D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+
+            gl.texStorage3D(
+                gl.TEXTURE_3D,  // target
+                Math.log2(SIZE),              // levels
+                gl.R32F,        // internalformat
+                SIZE,           // width
+                SIZE,           // height
+                SIZE            // depth
+                );
+
+            gl.texSubImage3D(
+                gl.TEXTURE_3D,  // target
+                0,              // level
+                0,
+                0,
+                0,
+                SIZE,           // width
+                SIZE,           // height
+                SIZE,           // depth
+                gl.RED,         // format
+                gl.FLOAT,       // type
+                data
+                );
+            gl.generateMipmap(gl.TEXTURE_3D);
+
+            return texture3D;
+        }
+
+    })();
+    </script>
+
+</body>
+
+</html>

--- a/samples/texture_immutable.html
+++ b/samples/texture_immutable.html
@@ -15,7 +15,7 @@
 
 <body>
     <div id="info">WebGL 2 Samples - texture_immutable</div>
-    <p id="description">Immutable texture refers to the texture's allocation, not the content of the texture. Therefore, new pixel data can be uploaded, but not the size of the texture storage</p>
+    <p id="description">Immutable texture refers to the texture's allocation, not the content of the texture. Therefore, new pixel data can be uploaded, but the size of the texture storage can't change.</p>
 
     <!-- WebGL 2 shaders -->
     <script id="vs" type="x-shader/x-vertex">
@@ -300,7 +300,6 @@
 
             return texture3D;
         }
-
     })();
     </script>
 


### PR DESCRIPTION
Works perfectly for texStorage2D on both Chrome OSX and Firefox OSX. However, for texStorage3D, Firefox OSX allocated the storage fine but Chrome OSX got an error for WebGL context lost. I think this is good to merge and if it's a Chrome bug I will submit a ticket to Chromium.
