### PR TITLE
Updated samples to use gl-matrix-min.js instead of gl-matrix.js and clean up sample descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ Inspired by and ported from Christophe Riccio's ([@Groovounet](https://github.co
 |[texture_format](http://webglsamples.org/WebGL2Samples/#texture_format)|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|
 |[texture_fetch](http://webglsamples.org/WebGL2Samples/#texture_fetch)|:white_check_mark:|:grey_question:|:white_check_mark:|:grey_question:|
 |[texture_grad](http://webglsamples.org/WebGL2Samples/#texture_grad)|:white_check_mark:|:grey_question:|:white_check_mark:|:grey_question:|
-|[texture_3d](http://webglsamples.org/WebGL2Samples/#texture_3d)|:x:GL ERROR :GL_INVALID_OPERATION : glGenerateMipmap: Can not generate mips|:white_check_mark:|:x: drawArraysInstanced: Active texture 0 for target 0x806f is 'incomplete'|:white_check_mark:|
-|[texture_immutable](http://webglsamples.org/WebGL2Samples/#texture_immutable)|:white_check_mark: Need to update for texStorage3D|:white_check_mark: Need to update for texStorage3D|:white_check_mark: Need to update for texStorage3D|:white_check_mark:|
+|[texture_3d](http://webglsamples.org/WebGL2Samples/#texture_3d)(currently not working for texture 3D)|:x:GL ERROR :GL_INVALID_OPERATION : glGenerateMipmap: Can not generate mips|:white_check_mark:|:x: drawArraysInstanced: Active texture 0 for target 0x806f is 'incomplete'|:white_check_mark:|
+|[texture_immutable](http://webglsamples.org/WebGL2Samples/#texture_immutable) (currently not working for texture 3D)|:white_check_mark: Need to update for texStorage3D|:white_check_mark: Need to update for texStorage3D|:white_check_mark: Need to update for texStorage3D|:white_check_mark:|
 |[texture_integer](http://webglsamples.org/WebGL2Samples/#texture_integer)|:white_check_mark:|:grey_question:|:x: Error: Driver ran out of memory during upload|:grey_question:|
 |[texture_lod](http://webglsamples.org/WebGL2Samples/#texture_lod)|:white_check_mark:|:grey_question:|:white_check_mark:|:grey_question:|
 |[texture_offset](http://webglsamples.org/WebGL2Samples/#texture_offset)|:white_check_mark:|:white_check_mark:|:white_check_mark:|:white_check_mark:|

--- a/samples/draw_instanced.html
+++ b/samples/draw_instanced.html
@@ -11,6 +11,9 @@
 
 <body>
     <div id="info">WebGL 2 Samples - draw_instanced</div>
+    <p id="description">
+        This samples demonstrates the use of gl.DrawArraysInstanced()
+    </p>
 
     <script id="vs" type="x-shader/x-vertex">
         #version 300 es

--- a/samples/fbo_blit.html
+++ b/samples/fbo_blit.html
@@ -11,6 +11,9 @@
 
 <body>
     <div id="info">WebGL 2 Samples - fbo_blit</div>
+    <p id="description">
+        This samples demonstrates blitting on frame buffer objects.
+    </p>
 
     <!-- WebGL 2 shaders -->
     <script id="vs" type="x-shader/x-vertex">
@@ -71,7 +74,7 @@
         var mvpLocation = gl.getUniformLocation(program, 'MVP');
         var diffuseLocation = gl.getUniformLocation(program, 'diffuse');
 
-        // -- Init buffers: 
+        // -- Init buffers:
         var positions = new Float32Array([
             -1.0, -1.0,
              1.0, -1.0,
@@ -117,12 +120,12 @@
         gl.bindVertexArray(null);
 
         loadImage('../assets/img/Di-3d.png', function(image) {
-            
+
             var FRAMEBUFFER_SIZE = {
-                x: image.width, 
+                x: image.width,
                 y: image.height
             };
-            
+
             // -- Init Texture
             var textureDiffuse = gl.createTexture();
             gl.activeTexture(gl.TEXTURE0);
@@ -131,26 +134,26 @@
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, image);
-            
+
             var textureColorBuffer = gl.createTexture();
             gl.bindTexture(gl.TEXTURE_2D, textureColorBuffer);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
             gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
             gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, FRAMEBUFFER_SIZE.x, FRAMEBUFFER_SIZE.y, 0, gl.RGBA, gl.UNSIGNED_BYTE, null);
             gl.bindTexture(gl.TEXTURE_2D, null);
-            
+
             // -- Init Frame Buffer
             var framebufferRender = gl.createFramebuffer();
             var framebufferResolve = gl.createFramebuffer();
-            
+
             var colorRenderbuffer = gl.createRenderbuffer();
             gl.bindRenderbuffer(gl.RENDERBUFFER, colorRenderbuffer);
             gl.renderbufferStorage(gl.RENDERBUFFER, gl.RGBA4, FRAMEBUFFER_SIZE.x, FRAMEBUFFER_SIZE.y);
-            
+
             gl.bindFramebuffer(gl.FRAMEBUFFER, framebufferRender);
             gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, colorRenderbuffer);
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-            
+
             gl.bindFramebuffer(gl.FRAMEBUFFER, framebufferResolve);
             gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, textureColorBuffer, 0);
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
@@ -158,12 +161,12 @@
             // -- Render
             gl.useProgram(program);
             gl.uniform1i(diffuseLocation, 0);
-            
+
             // Pass 1
             gl.bindFramebuffer(gl.FRAMEBUFFER, framebufferRender);
             gl.viewport(0, 0, FRAMEBUFFER_SIZE.x, FRAMEBUFFER_SIZE.y);
             gl.clearBufferfv(gl.COLOR, 0, [0.3, 0.3, 0.3, 1.0]);
-            
+
             // Render FBO
             var SCALE = new Float32Array([
                 0.8, 0.0, 0.0, 0.0,
@@ -177,12 +180,12 @@
             gl.bindVertexArray(vertexArray);
             gl.drawArrays(gl.TRIANGLES, 0, 6);
             gl.bindTexture(gl.TEXTURE_2D, null);
-            
+
             // Blit framebuffers
             gl.bindFramebuffer(gl.READ_FRAMEBUFFER, framebufferRender);
             gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, framebufferResolve);
             gl.clearBufferfv(gl.COLOR, 0, [0.7, 0.0, 0.0, 1.0]);
-            
+
             var TILE = 4;
             var BORDER = 2;
             for(var j = 0; j < TILE; j++) {
@@ -190,23 +193,23 @@
                     if((i + j) % 2) {
                         continue;
                     }
-                    
+
                     gl.blitFramebuffer(
-                        0, 0, FRAMEBUFFER_SIZE.x, FRAMEBUFFER_SIZE.y, 
-                        FRAMEBUFFER_SIZE.x / TILE * (i + 0) + BORDER, 
-                        FRAMEBUFFER_SIZE.x / TILE * (j + 0) + BORDER, 
-                        FRAMEBUFFER_SIZE.y / TILE * (i + 1) - BORDER, 
-                        FRAMEBUFFER_SIZE.y / TILE * (j + 1) - BORDER, 
+                        0, 0, FRAMEBUFFER_SIZE.x, FRAMEBUFFER_SIZE.y,
+                        FRAMEBUFFER_SIZE.x / TILE * (i + 0) + BORDER,
+                        FRAMEBUFFER_SIZE.x / TILE * (j + 0) + BORDER,
+                        FRAMEBUFFER_SIZE.y / TILE * (i + 1) - BORDER,
+                        FRAMEBUFFER_SIZE.y / TILE * (j + 1) - BORDER,
                         gl.COLOR_BUFFER_BIT, gl.LINEAR
                     );
                 }
             }
-                        
+
             // Pass 2
             gl.bindFramebuffer(gl.FRAMEBUFFER, null);
             gl.viewport(0, 0, canvas.width, canvas.height);
             gl.clearBufferfv(gl.COLOR, 0, [0.0, 0.0, 0.0, 1.0]);
-            
+
             // Render FB
             var IDENTITY = new Float32Array([
                 1.0, 0.0, 0.0, 0.0,

--- a/samples/fbo_multisample.html
+++ b/samples/fbo_multisample.html
@@ -11,7 +11,7 @@
 <body>
     <div id="info">WebGL 2 Samples - fbo_multisample</div>
     <p id="description">
-        Render to a texture enabling multisample. 
+        Render to a texture with multi-sampling enabled.
     </p>
 
     <!-- WebGL 2 shaders -->
@@ -42,7 +42,7 @@
             color = vec4(1.0, 0.5, 0.0, 1.0);
         }
     </script>
-    
+
     <script id="vs-splash" type="x-shader/x-vertex">
         #version 300 es
         precision highp float;
@@ -103,15 +103,15 @@
             SPLASH: 1,
             MAX: 2
         };
-        
+
         var programs = [
             createProgram(gl, getShaderSource('vs-render'), getShaderSource('fs-render')),
-            createProgram(gl, getShaderSource('vs-splash'), getShaderSource('fs-splash')) 
+            createProgram(gl, getShaderSource('vs-splash'), getShaderSource('fs-splash'))
         ];
         var mvpLocationTexture = gl.getUniformLocation(programs[PROGRAM.TEXTURE], 'MVP');
         var mvpLocation = gl.getUniformLocation(programs[PROGRAM.SPLASH], 'MVP');
         var diffuseLocation = gl.getUniformLocation(programs[PROGRAM.SPLASH], 'diffuse');
-        
+
         // -- Init primitive data
         var vertexCount = 18;
         var data = new Float32Array(vertexCount * 2);
@@ -123,13 +123,13 @@
             data[2 * i] = radius * Math.sin(angle);
             data[2 * i + 1] = radius * Math.cos(angle);
         }
-        
+
         // -- Init buffers
         var vertexDataBuffer = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, vertexDataBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, data, gl.STATIC_DRAW);
         gl.bindBuffer(gl.ARRAY_BUFFER, null);
-        
+
         var positions = new Float32Array([
             -1.0, -1.0,
              1.0, -1.0,
@@ -159,7 +159,7 @@
         // -- Init Texture
         // used for draw framebuffer storage
         var FRAMEBUFFER_SIZE = {
-            x: canvas.width, 
+            x: canvas.width,
             y: canvas.height
         };
         var texture = gl.createTexture();
@@ -171,7 +171,7 @@
 
         // -- Init Frame Buffers
         var FRAMEBUFFER = {
-            RENDERBUFFER: 0, 
+            RENDERBUFFER: 0,
             COLORBUFFER: 1
         };
         var framebuffers = [
@@ -181,11 +181,11 @@
         var colorRenderbuffer = gl.createRenderbuffer();
         gl.bindRenderbuffer(gl.RENDERBUFFER, colorRenderbuffer);
         gl.renderbufferStorageMultisample(gl.RENDERBUFFER, 4, gl.RGBA8, FRAMEBUFFER_SIZE.x, FRAMEBUFFER_SIZE.y);
-        
+
         gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffers[FRAMEBUFFER.RENDERBUFFER]);
         gl.framebufferRenderbuffer(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.RENDERBUFFER, colorRenderbuffer);
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
-        
+
         gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffers[FRAMEBUFFER.COLORBUFFER]);
         gl.framebufferTexture2D(gl.FRAMEBUFFER, gl.COLOR_ATTACHMENT0, gl.TEXTURE_2D, texture, 0);
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
@@ -195,16 +195,16 @@
             gl.createVertexArray(),
             gl.createVertexArray()
         ];
-        
+
         var vertexPosLocation = 0; // set with GLSL layout qualifier
-        
+
         gl.bindVertexArray(vertexArrays[PROGRAM.TEXTURE]);
         gl.enableVertexAttribArray(vertexPosLocation);
         gl.bindBuffer(gl.ARRAY_BUFFER, vertexDataBuffer);
         gl.vertexAttribPointer(vertexPosLocation, 2, gl.FLOAT, false, 0, 0);
         gl.bindBuffer(gl.ARRAY_BUFFER, null);
         gl.bindVertexArray(null);
-        
+
         gl.bindVertexArray(vertexArrays[PROGRAM.SPLASH]);
 
         gl.enableVertexAttribArray(vertexPosLocation);
@@ -219,29 +219,29 @@
         gl.bindBuffer(gl.ARRAY_BUFFER, null);
 
         gl.bindVertexArray(null);
-        
+
         // -- Render
-        
+
         // Pass 1
         gl.bindFramebuffer(gl.FRAMEBUFFER, framebuffers[FRAMEBUFFER.RENDERBUFFER]);
         gl.clearBufferfv(gl.COLOR, 0, [0.0, 0.0, 0.0, 1.0]);
         gl.useProgram(programs[PROGRAM.TEXTURE]);
         gl.bindVertexArray(vertexArrays[PROGRAM.TEXTURE]);
-        
+
         var IDENTITY = mat4.create();
         gl.uniformMatrix4fv(mvpLocationTexture, false, IDENTITY);
         gl.drawArrays(gl.LINE_LOOP, 0, vertexCount);
-        
+
         // Blit framebuffers, no Multisample texture 2d in WebGL 2
         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, framebuffers[FRAMEBUFFER.RENDERBUFFER]);
         gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, framebuffers[FRAMEBUFFER.COLORBUFFER]);
         gl.clearBufferfv(gl.COLOR, 0, [0.0, 0.0, 0.0, 1.0]);
         gl.blitFramebuffer(
-            0, 0, FRAMEBUFFER_SIZE.x, FRAMEBUFFER_SIZE.y, 
-            0, 0, FRAMEBUFFER_SIZE.x, FRAMEBUFFER_SIZE.y, 
+            0, 0, FRAMEBUFFER_SIZE.x, FRAMEBUFFER_SIZE.y,
+            0, 0, FRAMEBUFFER_SIZE.x, FRAMEBUFFER_SIZE.y,
             gl.COLOR_BUFFER_BIT, gl.NEAREST
         );
-        
+
         // Pass 2
         gl.bindFramebuffer(gl.FRAMEBUFFER, null);
         gl.useProgram(programs[PROGRAM.SPLASH]);
@@ -249,18 +249,18 @@
         gl.activeTexture(gl.TEXTURE0);
         gl.bindTexture(gl.TEXTURE_2D, texture);
         gl.bindVertexArray(vertexArrays[PROGRAM.SPLASH]);
-        
+
         gl.clearColor(0.0, 0.0, 0.0, 1.0);
         gl.clear(gl.COLOR_BUFFER_BIT);
-        
+
         var scaleVector3 = vec3.create();
         vec3.set(scaleVector3, 8.0, 8.0, 8.0);
         var mvp = mat4.create();
         mat4.scale(mvp, IDENTITY, scaleVector3);
-        
+
         gl.uniformMatrix4fv(mvpLocation, false, mvp);
         gl.drawArrays(gl.TRIANGLES, 0, 6);
-        
+
         // -- Delete WebGL resources
         gl.deleteBuffer(vertexPosBuffer);
         gl.deleteBuffer(vertexTexBuffer);
@@ -272,7 +272,7 @@
         gl.deleteVertexArray(vertexArrays[PROGRAM.SPLASH]);
         gl.deleteProgram(programs[PROGRAM.TEXTURE]);
         gl.deleteProgram(programs[PROGRAM.SPLASH]);
-        
+
     })();
     </script>
 

--- a/samples/fbo_rtt_texture_array.html
+++ b/samples/fbo_rtt_texture_array.html
@@ -12,6 +12,9 @@
 
 <body>
     <div id="info">WebGL 2 Samples - fbo_rtt_texture_array</div>
+    <p id="description">
+        This sample demonstrates rendering to texture in a frame buffer using a texture array.
+    </p>
 
     <script id="vs-layer" type="x-shader/x-vertex">
         #version 300 es

--- a/samples/query_occlusion.html
+++ b/samples/query_occlusion.html
@@ -11,6 +11,9 @@
 
 <body>
     <div id="info">WebGL 2 Samples - query_occlusion</div>
+    <p id="description">
+        This sample demonstrates query occlusion.
+    </p>
     <p>&nbsp;</p>
     <div id="samplesPassed"></div>
 

--- a/samples/sampler_filter.html
+++ b/samples/sampler_filter.html
@@ -12,7 +12,9 @@
 
 <body>
     <div id="info">WebGL 2 Samples - sampler_filter</div>
-
+    <p id="description">
+    This sample demonstrates different texture filtering options for min/mag filters.
+    </p>
     <script id="vs" type="x-shader/x-vertex">
         #version 300 es
         #define POSITION_LOCATION 0

--- a/samples/sampler_wrap.html
+++ b/samples/sampler_wrap.html
@@ -12,6 +12,9 @@
 
 <body>
     <div id="info">WebGL 2 Samples - sampler_wrap</div>
+    <p id="description">
+        This sample demonstrates texture wrapping.
+    </p>
 
     <!-- WebGL 2 shaders -->
     <script id="vs" type="x-shader/x-vertex">

--- a/samples/style.css
+++ b/samples/style.css
@@ -22,6 +22,11 @@ body {
     padding: 5px;
 }
 
+.float {
+    float: left;
+    top: 10px;
+}
+
 a {
     color: #0080ff;
 }

--- a/samples/texture_3d.html
+++ b/samples/texture_3d.html
@@ -14,7 +14,9 @@
 
 <body>
     <div id="info">WebGL 2 Samples - texture_3d</div>
-
+    <p id="description">
+        This sample demonstrates creating a custom 3D texture from simplex noise.
+    </p>
     <!-- WebGL 2 shaders.
         This section is adapted from Example 6.15 and 6.16,
         OpenGL® Programming Guide: The Official Guide to Learning OpenGL®, Version 4.3,

--- a/samples/texture_3d.html
+++ b/samples/texture_3d.html
@@ -8,7 +8,7 @@
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <link rel="stylesheet" href="style.css">
     <script src="utility.js"></script>
-    <script src="third-party/gl-matrix.js"></script>
+    <script src="third-party/gl-matrix-min.js"></script>
     <script src="third-party/noise3D.js"></script>
 </head>
 
@@ -159,8 +159,6 @@
             gl.FLOAT,       // type
             data            // pixel
             );
-
-        gl.generateMipmap(gl.TEXTURE_3D);
 
         // -- Initialize program
 

--- a/samples/texture_format.html
+++ b/samples/texture_format.html
@@ -11,6 +11,9 @@
 
 <body>
     <div id="info">WebGL 2 Samples - texture_format</div>
+    <p id="description">
+        This sample demonstrates loading a variety of texture formats.
+    </p>
 
     <!-- WebGL 2 shaders -->
     <script id="vs" type="x-shader/x-vertex">

--- a/samples/texture_immutable.html
+++ b/samples/texture_immutable.html
@@ -15,7 +15,7 @@
 
 <body>
     <div id="info">WebGL 2 Samples - texture_immutable</div>
-    <p id="description">Immutable texture refers to the texture's allocation, not the content of the texture. Therefore, new pixel data can be uploaded, but the size of the texture storage can't change. (currently not working for texture 3D)</p>
+    <p id="description">Immutable texture refers to the texture's allocation, not the content of the texture. Therefore, new pixel data can be uploaded, but the size of the texture storage can't change.</p>
 
     <!-- WebGL 2 shaders -->
     <script id="vs" type="x-shader/x-vertex">

--- a/samples/texture_immutable.html
+++ b/samples/texture_immutable.html
@@ -7,7 +7,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <link rel="stylesheet" href="style.css">
-    <script src="third-party/gl-matrix.js"></script>
+    <script src="third-party/gl-matrix-min.js"></script>
     <script src="third-party/noise3D.js"></script>
     <script src="utility.js"></script>
 
@@ -15,7 +15,7 @@
 
 <body>
     <div id="info">WebGL 2 Samples - texture_immutable</div>
-    <p id="description">Immutable texture refers to the texture's allocation, not the content of the texture. Therefore, new pixel data can be uploaded, but the size of the texture storage can't change.</p>
+    <p id="description">Immutable texture refers to the texture's allocation, not the content of the texture. Therefore, new pixel data can be uploaded, but the size of the texture storage can't change. (currently not working for texture 3D)</p>
 
     <!-- WebGL 2 shaders -->
     <script id="vs" type="x-shader/x-vertex">

--- a/samples/transform_feedback_separated_2.html
+++ b/samples/transform_feedback_separated_2.html
@@ -9,7 +9,7 @@
     <meta name="viewport" content="width=device-width, user-scalable=no, minimum-scale=1.0, maximum-scale=1.0">
     <link rel="stylesheet" href="style.css">
     <script src="utility.js"></script>
-    <script src="third-party/gl-matrix.js"></script>
+    <script src="third-party/gl-matrix-min.js"></script>
     <script src="third-party/noise3D.js"></script>
 </head>
 
@@ -105,7 +105,7 @@
             } else {
                 gl_Position = vec4(-100.0, -100.0, 0.0, 1.0);
             }
-            gl_PointSize = 10.0;
+            gl_PointSize = 2.0;
         }
     </script>
 


### PR DESCRIPTION
Note: texture3D stopped working, both before and after the change to gl-matrix-min.js, which is a dependency on generating noise3D. See #97 
