### PR TITLE
discard onunload clean

### DIFF
--- a/samples/texture_2d_array.html
+++ b/samples/texture_2d_array.html
@@ -185,14 +185,13 @@
             })();
         });
         
-        window.onunload = function() {
-            // -- Delete WebGL resources
-            gl.deleteBuffer(vertexPosBuffer);
-            gl.deleteBuffer(vertexTexBuffer);
-            gl.deleteTexture(texture);
-            gl.deleteProgram(program);
-            gl.deleteVertexArray(vertexArray);
-        };
+        // If you have a long-running page, and need to delete WebGL resources, use:
+        //
+        // gl.deleteBuffer(vertexPosBuffer);
+        // gl.deleteBuffer(vertexTexBuffer);
+        // gl.deleteTexture(texture);
+        // gl.deleteProgram(program);
+        // gl.deleteVertexArray(vertexArray);
     })();
     </script>
 

--- a/samples/texture_derivative.html
+++ b/samples/texture_derivative.html
@@ -322,15 +322,15 @@
             requestAnimationFrame(render);
         }
 
-        document.onunload = function() {
-            // Delete WebGL resources
-            gl.deleteBuffer(vertexPosBuffer);
-            gl.deleteBuffer(vertexTexBuffer);
-            gl.deleteBuffer(indexBuffer);
-            gl.deleteTexture(texture);
-            gl.deleteProgram(program);
-            gl.deleteVertexArray(vertexArray);
-        };
+        // If you have a long-running page, and need to delete WebGL resources, use:
+        //
+        // gl.deleteBuffer(vertexPosBuffer);
+        // gl.deleteBuffer(vertexTexBuffer);
+        // gl.deleteBuffer(indexBuffer);
+        // gl.deleteTexture(texture);
+        // gl.deleteProgram(program);
+        // gl.deleteVertexArray(vertexArray);
+        
     })();
     </script>
 

--- a/samples/texture_grad.html
+++ b/samples/texture_grad.html
@@ -326,15 +326,15 @@
             requestAnimationFrame(render);
         }
 
-        document.onunload = function() {
-            // Delete WebGL resources
-            gl.deleteBuffer(vertexPosBuffer);
-            gl.deleteBuffer(vertexTexBuffer);
-            gl.deleteBuffer(indexBuffer);
-            gl.deleteTexture(texture);
-            gl.deleteProgram(program);
-            gl.deleteVertexArray(vertexArray);
-        };
+        // If you have a long-running page, and need to delete WebGL resources, use:
+        // 
+        // gl.deleteBuffer(vertexPosBuffer);
+        // gl.deleteBuffer(vertexTexBuffer);
+        // gl.deleteBuffer(indexBuffer);
+        // gl.deleteTexture(texture);
+        // gl.deleteProgram(program);
+        // gl.deleteVertexArray(vertexArray);
+        
     })();
     </script>
 

--- a/samples/texture_lod.html
+++ b/samples/texture_lod.html
@@ -273,16 +273,16 @@
             requestAnimationFrame(render);
         }
         
-        window.onunload = function() {
-            // -- Delete WebGL resources
-            gl.deleteBuffer(vertexPosBuffer);
-            gl.deleteBuffer(vertexTexBuffer);
-            for (var j = 0; j < textures.length; ++j) {
-                gl.deleteTexture(textures[j]);
-            }
-            gl.deleteVertexArray(vertexArray);
-            gl.deleteProgram(program);
-        };
+        // If you have a long-running page, and need to delete WebGL resources, use:
+        //
+        // gl.deleteBuffer(vertexPosBuffer);
+        // gl.deleteBuffer(vertexTexBuffer);
+        // for (var j = 0; j < textures.length; ++j) {
+        //     gl.deleteTexture(textures[j]);
+        // }
+        // gl.deleteVertexArray(vertexArray);
+        // gl.deleteProgram(program);
+            
     })();
     </script>
 


### PR DESCRIPTION
fix #87 
- `glsl_flat_smooth_interpolators.html` and `texture_vertex.html` will be fixed in gltf_loader branch, due to buffer change
