### PR TITLE
Add vertexAttribDivisor to drawInstanced sample

### DIFF
--- a/samples/draw_instanced.html
+++ b/samples/draw_instanced.html
@@ -112,6 +112,7 @@
 
         // -- Delete WebGL resources
         gl.deleteBuffer(vertexPosBuffer);
+        gl.deleteBuffer(vertexColorBuffer);
         gl.deleteProgram(program);
         gl.deleteVertexArray(vertexArray);
     })();

--- a/samples/draw_instanced.html
+++ b/samples/draw_instanced.html
@@ -18,16 +18,18 @@
     <script id="vs" type="x-shader/x-vertex">
         #version 300 es
         #define POSITION_LOCATION 0
+        #define COLOR_LOCATION 1
         
         precision highp float;
         precision highp int;
 
         layout(location = POSITION_LOCATION) in vec2 pos;
-        flat out int instance;
+        layout(location = COLOR_LOCATION) in vec4 color;
+        flat out vec4 v_color;
 
         void main()
         {
-            instance = gl_InstanceID;
+            v_color = color;
             gl_Position = vec4(pos + vec2(float(gl_InstanceID) - 0.5, 0.0), 0.0, 1.0);
         }
     </script>
@@ -37,12 +39,12 @@
         precision highp float;
         precision highp int;
 
-        flat in int instance;
+        flat in vec4 v_color;
         out vec4 color;
 
         void main()
         {
-            color = vec4(1.0 - float(instance), 0.5, 0.0 + float(instance), 1.0);
+            color = v_color;
         }
     </script>
 
@@ -69,7 +71,12 @@
         var program = createProgram(gl, getShaderSource('vs'), getShaderSource('fs'));
         gl.useProgram(program);
 
-        // -- Init Buffer
+        // -- Init Vertex Array
+        var vertexArray = gl.createVertexArray();
+        gl.bindVertexArray(vertexArray);
+
+        // -- Init Buffers
+        var vertexPosLocation = 0;  // set with GLSL layout qualifier
         var vertices = new Float32Array([
             -0.3, -0.5,
              0.3, -0.5,
@@ -78,14 +85,20 @@
         var vertexPosBuffer = gl.createBuffer();
         gl.bindBuffer(gl.ARRAY_BUFFER, vertexPosBuffer);
         gl.bufferData(gl.ARRAY_BUFFER, vertices, gl.STATIC_DRAW);
-
-        // -- Init Vertex Array
-        var vertexArray = gl.createVertexArray();
-        gl.bindVertexArray(vertexArray);
-
-        var vertexPosLocation = 0;  // set with GLSL layout qualifier
         gl.enableVertexAttribArray(vertexPosLocation);
         gl.vertexAttribPointer(vertexPosLocation, 2, gl.FLOAT, false, 0, 0);
+
+        var vertexColorLocation = 1;  // set with GLSL layout qualifier
+        var colors = new Float32Array([
+            1.0, 0.5, 0.0,
+            0.0, 0.5, 1.0
+        ]);
+        var vertexColorBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, vertexColorBuffer);
+        gl.bufferData(gl.ARRAY_BUFFER, colors, gl.STATIC_DRAW);
+        gl.enableVertexAttribArray(vertexColorLocation);
+        gl.vertexAttribPointer(vertexColorLocation, 3, gl.FLOAT, false, 0, 0);
+        gl.vertexAttribDivisor(1, 1); // attribute used once per instance
 
         gl.bindVertexArray(null);
 

--- a/samples/draw_instanced.html
+++ b/samples/draw_instanced.html
@@ -98,7 +98,7 @@
         gl.bufferData(gl.ARRAY_BUFFER, colors, gl.STATIC_DRAW);
         gl.enableVertexAttribArray(vertexColorLocation);
         gl.vertexAttribPointer(vertexColorLocation, 3, gl.FLOAT, false, 0, 0);
-        gl.vertexAttribDivisor(1, 1); // attribute used once per instance
+        gl.vertexAttribDivisor(vertexColorLocation, 1); // attribute used once per instance
 
         gl.bindVertexArray(null);
 


### PR DESCRIPTION
A key thing that's missing from the drawInstanced samples is how to use vertexAttribDivisor. I've modified draw_instanced.html to use a per-instance color using vertexAttribDivisor. The position is still based on gl_InstanceID, so that's still being demonstrated as well.