### PR TITLE
Simplify transform feedback sample

### DIFF
--- a/samples/transform_feedback_separated_2.html
+++ b/samples/transform_feedback_separated_2.html
@@ -310,7 +310,7 @@
         // }
     })();
     </script>
-    <div id="highlightedLines"  style="display: none">#L318-L350</div>
+    <div id="highlightedLines"  style="display: none">#L262-L293</div>
 
 </body>
 

--- a/samples/transform_feedback_separated_2.html
+++ b/samples/transform_feedback_separated_2.html
@@ -308,7 +308,7 @@
         // }
     })();
     </script>
-    <div id="highlightedLines"  style="display: none">#L262-L293</div>
+    <div id="highlightedLines"  style="display: none">#L260-L291</div>
 
 </body>
 

--- a/samples/transform_feedback_separated_2.html
+++ b/samples/transform_feedback_separated_2.html
@@ -119,12 +119,7 @@
         var appStartTime = Date.now();
         var currentSourceIdx = 0;
 
-        // -- Init Program
-
-        var PROGRAM_EMIT = 0;
-        var PROGRAM_DRAW = 1;
-
-        var program = initPrograms();
+        var program = initProgram();
 
         // Get uniform locations for the draw program
         var drawTimeLocation = gl.getUniformLocation(program, 'u_time');
@@ -178,7 +173,6 @@
             gl.vertexAttribPointer(VELOCITY_LOCATION, 2, gl.FLOAT, false, 0, 0);
             gl.enableVertexAttribArray(VELOCITY_LOCATION);
 
-
             particleVBOs[i][SPAWNTIME_LOCATION] = gl.createBuffer();
             gl.bindBuffer(gl.ARRAY_BUFFER, particleVBOs[i][SPAWNTIME_LOCATION]);
             gl.bufferData(gl.ARRAY_BUFFER, particleSpawntime, gl.STREAM_COPY);
@@ -201,9 +195,9 @@
         // -- Init TransformFeedback
         var transformFeedback = gl.createTransformFeedback();
 
-        render();
+        requestAnimationFrame(render);
 
-        function initPrograms() {
+        function initProgram() {
 
             // Setup program for transform feedback shaders
             function createShader(gl, source, type) {
@@ -213,38 +207,42 @@
                 return shader;
             }
 
-            var vshaderTransform = createShader(gl, getShaderSource('vs-draw'), gl.VERTEX_SHADER);
-            var fshaderTransform = createShader(gl, getShaderSource('fs-draw'), gl.FRAGMENT_SHADER);
+            var vshader = createShader(gl, getShaderSource('vs-draw'), gl.VERTEX_SHADER);
+            var fshader = createShader(gl, getShaderSource('fs-draw'), gl.FRAGMENT_SHADER);
 
-            var programEmit = gl.createProgram();
-            gl.attachShader(programEmit, vshaderTransform);
-            gl.deleteShader(vshaderTransform);
-            gl.attachShader(programEmit, fshaderTransform);
-            gl.deleteShader(fshaderTransform);
+            var program = gl.createProgram();
+            gl.attachShader(program, vshader);
+            gl.attachShader(program, fshader);
 
             var varyings = ['v_position', 'v_velocity', 'v_spawntime', 'v_lifetime'];
-            gl.transformFeedbackVaryings(programEmit, varyings, gl.SEPARATE_ATTRIBS);
-            gl.linkProgram(programEmit);
+            gl.transformFeedbackVaryings(program, varyings, gl.SEPARATE_ATTRIBS);
+            gl.linkProgram(program);
 
             // check
-            var log = gl.getProgramInfoLog(programEmit);
+            var log = gl.getProgramInfoLog(program);
             if (log) {
                 console.log(log);
             }
 
-            log = gl.getShaderInfoLog(vshaderTransform);
+            log = gl.getShaderInfoLog(vshader);
             if (log) {
                 console.log(log);
             }
+
+            log = gl.getShaderInfoLog(fshader);
+            if (log) {
+                console.log(log);
+            }
+
+            gl.deleteShader(vshader);
+            gl.deleteShader(fshader);
 
             // Setup program for draw shader
             
-            return programEmit;
+            return program;
         }
 
         function render() {
-            // Spawn particles
-            emitParticles();
 
             var time = Date.now() - appStartTime;
 
@@ -255,17 +253,15 @@
             gl.clearColor(0.0, 0.0, 0.0, 1.0);
             gl.clear(gl.COLOR_BUFFER_BIT);
 
-            var programEmit = program;
-
             // Toggle source and destination VBO
-            var sourceVBO = particleVBOs[currentSourceIdx];
             var sourceVAO = particleVAOs[currentSourceIdx];
+            var sourceVBO = particleVBOs[currentSourceIdx];
 
             var destinationVBO = particleVBOs[(currentSourceIdx + 1) % 2];
 
             gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
 
-            gl.useProgram(programEmit);
+            gl.useProgram(program);
             gl.bindVertexArray(sourceVAO);
 
             // Set transform feedback buffer
@@ -288,6 +284,7 @@
 
             // Restore state
             gl.useProgram(null);
+            gl.bindVertexArray(null);
             gl.bindBuffer(gl.ARRAY_BUFFER, null);
             gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
             gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, null);
@@ -304,15 +301,13 @@
         // If you have a long-running page, and need to delete WebGL resources, use:
         //
         // gl.deleteTransformFeedback(transformFeedback);
-        // gl.deleteProgram(programs[PROGRAM_EMIT]);
-        // gl.deleteProgram(programs[PROGRAM_DRAW]);
-        // for (var i = 0; i < 2; ++i) {
-        //     for (var j = 0; j < Particle.MAX; ++j) {
+        // gl.deleteProgram(program);
+        // for (var i = 0; i < particleVAOs.length; ++i) {
+        //     gl.deleteVertexArray(i); 
+        //     for (var j = 0; j < NUM_LOCATIONS; ++j) {
         //         gl.deleteBuffer(particleVBOs[i][j]);
         //     }
         // }
-        // gl.deleteVertexArray(particleVAOs[PROGRAM_EMIT]);
-        // gl.deleteVertexArray(particleVAOs[PROGRAM_DRAW]);
     })();
     </script>
     <div id="highlightedLines"  style="display: none">#L318-L350</div>

--- a/samples/transform_feedback_separated_2.html
+++ b/samples/transform_feedback_separated_2.html
@@ -139,7 +139,7 @@
         var SPAWNTIME_LOCATION = 2;
         var LIFETIME_LOCATION = 3;
         var ID_LOCATION = 4;
-        var NUM_LOCATIONS;
+        var NUM_LOCATIONS = 5;
 
         for (var p = 0; p < NUM_PARTICLES; ++p) {
             particlePositions[p * 2] = 0.0;
@@ -192,11 +192,6 @@
             gl.enableVertexAttribArray(ID_LOCATION);
         }
 
-        // -- Init TransformFeedback
-        var transformFeedback = gl.createTransformFeedback();
-
-        requestAnimationFrame(render);
-
         function initProgram() {
 
             // Setup program for transform feedback
@@ -240,6 +235,17 @@
             return program;
         }
 
+        gl.useProgram(program);
+        gl.uniform4f(drawColorLocation, 0.0, 1.0, 1.0, 1.0);
+        gl.uniform2f(drawAccelerationLocation, 0.0, ACCELERATION);
+        
+        gl.enable(gl.BLEND);
+        gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
+
+        // -- Init TransformFeedback
+        var transformFeedback = gl.createTransformFeedback();
+        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
+
         function render() {
 
             var time = Date.now() - appStartTime;
@@ -253,13 +259,8 @@
 
             // Toggle source and destination VBO
             var sourceVAO = particleVAOs[currentSourceIdx];
-            var sourceVBO = particleVBOs[currentSourceIdx];
-
             var destinationVBO = particleVBOs[(currentSourceIdx + 1) % 2];
 
-            gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
-
-            gl.useProgram(program);
             gl.bindVertexArray(sourceVAO);
 
             // Set transform feedback buffer
@@ -270,31 +271,19 @@
 
             // Set uniforms
             gl.uniform1f(drawTimeLocation, time);
-            gl.uniform4f(drawColorLocation, 0.0, 1.0, 1.0, 1.0);
-            gl.uniform2f(drawAccelerationLocation, 0.0, ACCELERATION);
 
             // Draw particles using transform feedback
             gl.beginTransformFeedback(gl.POINTS);
-            gl.enable(gl.BLEND);
-            gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
             gl.drawArrays(gl.POINTS, 0, NUM_PARTICLES);
             gl.endTransformFeedback();
-
-            // Restore state
-            gl.useProgram(null);
-            gl.bindVertexArray(null);
-            gl.bindBuffer(gl.ARRAY_BUFFER, null);
-            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
-            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, null);
-            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 2, null);
-            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 3, null);
-            gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
 
             // Ping pong the buffers
             currentSourceIdx = (currentSourceIdx + 1) % 2;
 
             requestAnimationFrame(render);
         }
+
+        requestAnimationFrame(render);
 
         // If you have a long-running page, and need to delete WebGL resources, use:
         //
@@ -308,7 +297,7 @@
         // }
     })();
     </script>
-    <div id="highlightedLines"  style="display: none">#L260-L291</div>
+    <div id="highlightedLines"  style="display: none">#L246-L278</div>
 
 </body>
 

--- a/samples/transform_feedback_separated_2.html
+++ b/samples/transform_feedback_separated_2.html
@@ -139,14 +139,12 @@
         var particleLifetime = new Float32Array(NUM_PARTICLES);
         var particleIDs = new Float32Array(NUM_PARTICLES);
 
-        var Particle = {
-            POSITION: 0,
-            VELOCITY: 1,
-            SPAWN_TIME: 2,
-            LIFE_TIME: 3,
-            ID: 4,
-            MAX: 5
-        };
+        var POSITION_LOCATION = 0;
+        var VELOCITY_LOCATION = 1;
+        var SPAWNTIME_LOCATION = 2;
+        var LIFETIME_LOCATION = 3;
+        var ID_LOCATION = 4;
+        var NUM_LOCATIONS;
 
         for (var p = 0; p < NUM_PARTICLES; ++p) {
             particlePositions[p * 2] = 0.0;
@@ -158,40 +156,47 @@
             particleIDs[p] = p;
         }
 
-        // -- Init Buffer
-
-        var particleVBOs = new Array(2);
-
-        for (var i = 0; i < 2; ++i) {
-            particleVBOs[i] = new Array(Particle.MAX);
-            for (var j = 0; j < Particle.MAX; ++j) {
-                particleVBOs[i][j] = gl.createBuffer();
-            }
-
-            gl.bindBuffer(gl.ARRAY_BUFFER, particleVBOs[i][Particle.POSITION]);
-            gl.bufferData(gl.ARRAY_BUFFER, particlePositions, gl.STREAM_COPY);
-
-            gl.bindBuffer(gl.ARRAY_BUFFER, particleVBOs[i][Particle.VELOCITY]);
-            gl.bufferData(gl.ARRAY_BUFFER, particleVelocities, gl.STREAM_COPY);
-
-            gl.bindBuffer(gl.ARRAY_BUFFER, particleVBOs[i][Particle.SPAWN_TIME]);
-            gl.bufferData(gl.ARRAY_BUFFER, particleSpawntime, gl.STREAM_COPY);
-
-            gl.bindBuffer(gl.ARRAY_BUFFER, particleVBOs[i][Particle.LIFE_TIME]);
-            gl.bufferData(gl.ARRAY_BUFFER, particleLifetime, gl.STREAM_COPY);
-
-            gl.bindBuffer(gl.ARRAY_BUFFER, particleVBOs[i][Particle.ID]);
-            gl.bufferData(gl.ARRAY_BUFFER, particleIDs, gl.STATIC_READ);
-        }
-
         // -- Init Vertex Array
         var particleVAOs = [gl.createVertexArray(), gl.createVertexArray()];
 
-        var POSITION_LOCATION = 0;
-        var VELOCITY_LOCATION = 1;
-        var SPAWNTIME_LOCATION = 2;
-        var LIFETIME_LOCATION = 3;
-        var ID_LOCATION = 4;
+        var particleVBOs = new Array(particleVAOs.length);
+
+        for (var i = 0; i < particleVAOs.length; ++i) {
+            particleVBOs[i] = new Array(NUM_LOCATIONS);
+
+            gl.bindVertexArray(particleVAOs[i]);
+
+            particleVBOs[i][POSITION_LOCATION] = gl.createBuffer();
+            gl.bindBuffer(gl.ARRAY_BUFFER, particleVBOs[i][POSITION_LOCATION]);
+            gl.bufferData(gl.ARRAY_BUFFER, particlePositions, gl.STREAM_COPY);
+            gl.vertexAttribPointer(POSITION_LOCATION, 2, gl.FLOAT, false, 0, 0);
+            gl.enableVertexAttribArray(POSITION_LOCATION);
+
+            particleVBOs[i][VELOCITY_LOCATION] = gl.createBuffer();
+            gl.bindBuffer(gl.ARRAY_BUFFER, particleVBOs[i][VELOCITY_LOCATION]);
+            gl.bufferData(gl.ARRAY_BUFFER, particleVelocities, gl.STREAM_COPY);
+            gl.vertexAttribPointer(VELOCITY_LOCATION, 2, gl.FLOAT, false, 0, 0);
+            gl.enableVertexAttribArray(VELOCITY_LOCATION);
+
+
+            particleVBOs[i][SPAWNTIME_LOCATION] = gl.createBuffer();
+            gl.bindBuffer(gl.ARRAY_BUFFER, particleVBOs[i][SPAWNTIME_LOCATION]);
+            gl.bufferData(gl.ARRAY_BUFFER, particleSpawntime, gl.STREAM_COPY);
+            gl.vertexAttribPointer(SPAWNTIME_LOCATION, 1, gl.FLOAT, false, 0, 0);
+            gl.enableVertexAttribArray(SPAWNTIME_LOCATION);
+
+            particleVBOs[i][LIFETIME_LOCATION] = gl.createBuffer();
+            gl.bindBuffer(gl.ARRAY_BUFFER, particleVBOs[i][LIFETIME_LOCATION]);
+            gl.bufferData(gl.ARRAY_BUFFER, particleLifetime, gl.STREAM_COPY);
+            gl.vertexAttribPointer(LIFETIME_LOCATION, 1, gl.FLOAT, false, 0, 0);
+            gl.enableVertexAttribArray(LIFETIME_LOCATION);
+
+            particleVBOs[i][ID_LOCATION] = gl.createBuffer();
+            gl.bindBuffer(gl.ARRAY_BUFFER, particleVBOs[i][ID_LOCATION]);
+            gl.bufferData(gl.ARRAY_BUFFER, particleIDs, gl.STATIC_READ);
+            gl.vertexAttribPointer(ID_LOCATION, 1, gl.FLOAT, false, 0, 0);
+            gl.enableVertexAttribArray(ID_LOCATION);
+        }
 
         // -- Init TransformFeedback
         var transformFeedback = gl.createTransformFeedback();
@@ -237,35 +242,6 @@
             return programEmit;
         }
 
-        function setupVertexAttributes(vaoId, vboArray) {
-            gl.bindVertexArray(vaoId);
-
-            gl.bindBuffer(gl.ARRAY_BUFFER, vboArray[Particle.POSITION]);
-            gl.vertexAttribPointer(POSITION_LOCATION, 2, gl.FLOAT, false, 0, 0);
-
-            gl.bindBuffer(gl.ARRAY_BUFFER, vboArray[Particle.VELOCITY]);
-            gl.vertexAttribPointer(VELOCITY_LOCATION, 2, gl.FLOAT, false, 0, 0);
-
-            gl.bindBuffer(gl.ARRAY_BUFFER, vboArray[Particle.SPAWN_TIME]);
-            gl.vertexAttribPointer(SPAWNTIME_LOCATION, 1, gl.FLOAT, false, 0, 0);
-
-            gl.bindBuffer(gl.ARRAY_BUFFER, vboArray[Particle.LIFE_TIME]);
-            gl.vertexAttribPointer(LIFETIME_LOCATION, 1, gl.FLOAT, false, 0, 0);
-
-            gl.bindBuffer(gl.ARRAY_BUFFER, vboArray[Particle.ID]);
-            gl.vertexAttribPointer(ID_LOCATION, 1, gl.FLOAT, false, 0, 0);
-
-            gl.enableVertexAttribArray(POSITION_LOCATION);
-            gl.enableVertexAttribArray(VELOCITY_LOCATION);
-            gl.enableVertexAttribArray(SPAWNTIME_LOCATION);
-            gl.enableVertexAttribArray(LIFETIME_LOCATION);
-            gl.enableVertexAttribArray(ID_LOCATION);
-        }
-
-        function emitParticles() {
-            
-        }
-
         function render() {
             // Spawn particles
             emitParticles();
@@ -279,8 +255,6 @@
             gl.clearColor(0.0, 0.0, 0.0, 1.0);
             gl.clear(gl.COLOR_BUFFER_BIT);
 
-            setupVertexAttributes(particleVAOs[currentSourceIdx], particleVBOs[currentSourceIdx]);
-
             var programEmit = program;
 
             // Toggle source and destination VBO
@@ -292,14 +266,13 @@
             gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
 
             gl.useProgram(programEmit);
-
-            setupVertexAttributes(sourceVAO, sourceVBO);
+            gl.bindVertexArray(sourceVAO);
 
             // Set transform feedback buffer
-            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, destinationVBO[Particle.POSITION]);
-            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, destinationVBO[Particle.VELOCITY]);
-            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 2, destinationVBO[Particle.SPAWN_TIME]);
-            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 3, destinationVBO[Particle.LIFE_TIME]);
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, destinationVBO[POSITION_LOCATION]);
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, destinationVBO[VELOCITY_LOCATION]);
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 2, destinationVBO[SPAWNTIME_LOCATION]);
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 3, destinationVBO[LIFETIME_LOCATION]);
 
             // Set uniforms
             gl.uniform1f(drawTimeLocation, time);

--- a/samples/transform_feedback_separated_2.html
+++ b/samples/transform_feedback_separated_2.html
@@ -63,12 +63,7 @@
                 v_lifetime = a_lifetime;
             }
 
-            float deltaTime = u_time - a_spawntime;
-            if (deltaTime < a_lifetime) {
-                gl_Position = vec4(a_position, 0.0, 1.0);
-            } else {
-                gl_Position = vec4(-100.0, -100.0, 0.0, 1.0);
-            }
+            gl_Position = vec4(v_position, 0.0, 1.0);
             gl_PointSize = 2.0;
         }
     </script>

--- a/samples/transform_feedback_separated_2.html
+++ b/samples/transform_feedback_separated_2.html
@@ -18,7 +18,7 @@
     <p id="description">Using transform feedback in a simple particle system</p>
 
     <!-- WebGL 2 shaders -->
-    <script id="vs-emit" type="x-shader/x-vertex">
+    <script id="vs-draw" type="x-shader/x-vertex">
         #version 300 es
         #define POSITION_LOCATION 0
         #define VELOCITY_LOCATION 1
@@ -62,43 +62,7 @@
                 v_spawntime = a_spawntime;
                 v_lifetime = a_lifetime;
             }
-        }
-    </script>
 
-    <!-- Unsused -->
-    <script id="fs-emit" type="x-shader/x-fragment">
-        #version 300 es
-        precision highp float;
-        precision highp int;
-
-        out vec4 color;
-
-        void main()
-        {
-            color = vec4(1.0);
-        }
-    </script>
-
-    <script id="vs-draw" type="x-shader/x-vertex">
-        #version 300 es
-        #define POSITION_LOCATION 0
-        #define VELOCITY_LOCATION 1
-        #define SPAWNTIME_LOCATION 2
-        #define LIFETIME_LOCATION 3
-
-        precision highp float;
-        precision highp int;
-
-        uniform float u_time;
-        uniform vec2 u_acceleration;
-
-        layout(location = POSITION_LOCATION) in vec2 a_position;
-        layout(location = VELOCITY_LOCATION) in vec2 a_velocity;
-        layout(location = SPAWNTIME_LOCATION) in float a_spawntime;
-        layout(location = LIFETIME_LOCATION) in float a_lifetime;
-
-        void main()
-        {
             float deltaTime = u_time - a_spawntime;
             if (deltaTime < a_lifetime) {
                 gl_Position = vec4(a_position, 0.0, 1.0);
@@ -160,16 +124,12 @@
         var PROGRAM_EMIT = 0;
         var PROGRAM_DRAW = 1;
 
-        var programs = initPrograms();
-
-        // Get uniform locations for the transform feedback program
-        var emitTimeLocation = gl.getUniformLocation(programs[PROGRAM_EMIT], 'u_time');
-        var emitAccelerationLocation = gl.getUniformLocation(programs[PROGRAM_EMIT], 'u_acceleration');
+        var program = initPrograms();
 
         // Get uniform locations for the draw program
-        var drawTimeLocation = gl.getUniformLocation(programs[PROGRAM_DRAW], 'u_time');
-        var drawAccelerationLocation = gl.getUniformLocation(programs[PROGRAM_DRAW], 'u_acceleration');
-        var drawColorLocation = gl.getUniformLocation(programs[PROGRAM_DRAW], 'u_color');
+        var drawTimeLocation = gl.getUniformLocation(program, 'u_time');
+        var drawAccelerationLocation = gl.getUniformLocation(program, 'u_acceleration');
+        var drawColorLocation = gl.getUniformLocation(program, 'u_color');
 
         // -- Initialize particle data
 
@@ -248,8 +208,8 @@
                 return shader;
             }
 
-            var vshaderTransform = createShader(gl, getShaderSource('vs-emit'), gl.VERTEX_SHADER);
-            var fshaderTransform = createShader(gl, getShaderSource('fs-emit'), gl.FRAGMENT_SHADER);
+            var vshaderTransform = createShader(gl, getShaderSource('vs-draw'), gl.VERTEX_SHADER);
+            var fshaderTransform = createShader(gl, getShaderSource('fs-draw'), gl.FRAGMENT_SHADER);
 
             var programEmit = gl.createProgram();
             gl.attachShader(programEmit, vshaderTransform);
@@ -273,10 +233,8 @@
             }
 
             // Setup program for draw shader
-            var programDraw = createProgram(gl, getShaderSource('vs-draw'), getShaderSource('fs-draw'));
-
-            var programs = [programEmit, programDraw];
-            return programs;
+            
+            return programEmit;
         }
 
         function setupVertexAttributes(vaoId, vboArray) {
@@ -305,9 +263,25 @@
         }
 
         function emitParticles() {
+            
+        }
+
+        function render() {
+            // Spawn particles
+            emitParticles();
+
             var time = Date.now() - appStartTime;
 
-            var programEmit = programs[PROGRAM_EMIT];
+            // Set the viewport
+            gl.viewport(0, 0, canvas.width, canvas.height - 10);
+
+            // Clear color buffer
+            gl.clearColor(0.0, 0.0, 0.0, 1.0);
+            gl.clear(gl.COLOR_BUFFER_BIT);
+
+            setupVertexAttributes(particleVAOs[currentSourceIdx], particleVBOs[currentSourceIdx]);
+
+            var programEmit = program;
 
             // Toggle source and destination VBO
             var sourceVBO = particleVBOs[currentSourceIdx];
@@ -327,20 +301,19 @@
             gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 2, destinationVBO[Particle.SPAWN_TIME]);
             gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 3, destinationVBO[Particle.LIFE_TIME]);
 
-            // Turn off rasterization - we are not drawing
-            gl.enable(gl.RASTERIZER_DISCARD);
-
             // Set uniforms
-            gl.uniform1f(emitTimeLocation, time);
-            gl.uniform2f(emitAccelerationLocation, 0.0, ACCELERATION);
+            gl.uniform1f(drawTimeLocation, time);
+            gl.uniform4f(drawColorLocation, 0.0, 1.0, 1.0, 1.0);
+            gl.uniform2f(drawAccelerationLocation, 0.0, ACCELERATION);
 
             // Emit particles using transform feedback
             gl.beginTransformFeedback(gl.POINTS);
+            gl.enable(gl.BLEND);
+            gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
             gl.drawArrays(gl.POINTS, 0, NUM_PARTICLES);
             gl.endTransformFeedback();
 
             // Restore state
-            gl.disable(gl.RASTERIZER_DISCARD);
             gl.useProgram(null);
             gl.bindBuffer(gl.ARRAY_BUFFER, null);
             gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
@@ -351,35 +324,6 @@
 
             // Ping pong the buffers
             currentSourceIdx = (currentSourceIdx + 1) % 2;
-        }
-
-        function render() {
-            // Spawn particles
-            emitParticles();
-
-            var time = Date.now() - appStartTime;
-
-            // Set the viewport
-            gl.viewport(0, 0, canvas.width, canvas.height - 10);
-
-            // Clear color buffer
-            gl.clearColor(0.0, 0.0, 0.0, 1.0);
-            gl.clear(gl.COLOR_BUFFER_BIT);
-
-            setupVertexAttributes(particleVAOs[currentSourceIdx], particleVBOs[currentSourceIdx]);
-
-            gl.useProgram(programs[PROGRAM_DRAW]);
-
-            // Set uniforms
-            gl.uniform1f(drawTimeLocation, time);
-            gl.uniform4f(drawColorLocation, 0.0, 1.0, 1.0, 1.0);
-            gl.uniform2f(drawAccelerationLocation, 0.0, ACCELERATION);
-
-            // Enable blending
-            gl.enable(gl.BLEND);
-            gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
-
-            gl.drawArrays(gl.POINTS, 0, NUM_PARTICLES);
 
             requestAnimationFrame(render);
         }

--- a/samples/transform_feedback_separated_2.html
+++ b/samples/transform_feedback_separated_2.html
@@ -151,7 +151,7 @@
             particleIDs[p] = p;
         }
 
-        // -- Init Vertex Array
+        // -- Init Vertex Arrays and Buffers
         var particleVAOs = [gl.createVertexArray(), gl.createVertexArray()];
 
         var particleVBOs = new Array(particleVAOs.length);
@@ -199,7 +199,7 @@
 
         function initProgram() {
 
-            // Setup program for transform feedback shaders
+            // Setup program for transform feedback
             function createShader(gl, source, type) {
                 var shader = gl.createShader(type);
                 gl.shaderSource(shader, source);
@@ -237,8 +237,6 @@
             gl.deleteShader(vshader);
             gl.deleteShader(fshader);
 
-            // Setup program for draw shader
-            
             return program;
         }
 
@@ -275,7 +273,7 @@
             gl.uniform4f(drawColorLocation, 0.0, 1.0, 1.0, 1.0);
             gl.uniform2f(drawAccelerationLocation, 0.0, ACCELERATION);
 
-            // Emit particles using transform feedback
+            // Draw particles using transform feedback
             gl.beginTransformFeedback(gl.POINTS);
             gl.enable(gl.BLEND);
             gl.blendFunc(gl.SRC_ALPHA, gl.ONE);


### PR DESCRIPTION
There were two things about the original sample that I thought were confusing:
1. Splitting the rendering into separate "update" and "draw" passes is not necessary with transform feedback. You can draw and update in the same draw call.
2. VAOs store pointer and "enabled" state of attributes, so it isn't necessary to set up the vertex attributes after binding the VAO each frame.

Removing these redundancies reduces the size of the sample by about 20% and I think makes it clearer how things are working. It also highlights some advantages of WebGL 2, since neither simplification would be possible in WebGL 1.
 