### PR TITLE
Transform feedback objects

### DIFF
--- a/samples/transform_feedback_instanced.html
+++ b/samples/transform_feedback_instanced.html
@@ -303,17 +303,23 @@
 
         function transform() {
             var programTransform = programs[PROGRAM_TRANSFORM];
+            var destinationIdx = (currentSourceIdx + 1) % 2;
 
             // Toggle source and destination VBO
             var sourceVAO = vertexArrays[currentSourceIdx];
 
-            var destinationTransformFeedback = transformFeedbacks[(currentSourceIdx + 1) % 2];
-
+            var destinationTransformFeedback = transformFeedbacks[destinationIdx];
 
             gl.useProgram(programTransform);
 
             gl.bindVertexArray(sourceVAO);
             gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, destinationTransformFeedback);
+
+            // NOTE: The following two lines shouldn't be necessary, but are required to work in ANGLE
+            // due to a bug in its handling of transform feedback objects.
+            // https://bugs.chromium.org/p/angleproject/issues/detail?id=2051
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, vertexBuffers[destinationIdx][OFFSET_LOCATION]);
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, vertexBuffers[destinationIdx][ROTATION_LOCATION]);
 
             // Attributes per-vertex when doing transform feedback needs setting to 0 when doing transform feedback
             gl.vertexAttribDivisor(OFFSET_LOCATION, 0);

--- a/samples/transform_feedback_instanced.html
+++ b/samples/transform_feedback_instanced.html
@@ -213,6 +213,9 @@
 
         var vertexArrays = [gl.createVertexArray(), gl.createVertexArray()];
 
+        // Transform feedback objects track output buffer state
+        var transformFeedbacks = [gl.createTransformFeedback(), gl.createTransformFeedback()];
+
         var vertexBuffers = new Array(vertexArrays.length);
 
         for (var va = 0; va < vertexArrays.length; ++va) {
@@ -245,10 +248,15 @@
             gl.vertexAttribDivisor(COLOR_LOCATION, 1); // attribute used once per instance
 
             gl.bindVertexArray(null);
-        }
+            gl.bindBuffer(gl.ARRAY_BUFFER, null);
+            
+            // Set up output
+            gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedbacks[va]);
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, vertexBuffers[va][OFFSET_LOCATION]);
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, vertexBuffers[va][ROTATION_LOCATION]);
 
-        // -- Init TransformFeedback
-        var transformFeedback = gl.createTransformFeedback();
+            gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+        }
 
         render();
 
@@ -297,24 +305,19 @@
             var programTransform = programs[PROGRAM_TRANSFORM];
 
             // Toggle source and destination VBO
-            var sourceVBO = vertexBuffers[currentSourceIdx];
             var sourceVAO = vertexArrays[currentSourceIdx];
 
-            var destinationVBO = vertexBuffers[(currentSourceIdx + 1) % 2];
+            var destinationTransformFeedback = transformFeedbacks[(currentSourceIdx + 1) % 2];
 
-            gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
 
             gl.useProgram(programTransform);
 
             gl.bindVertexArray(sourceVAO);
+            gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, destinationTransformFeedback);
 
             // Attributes per-vertex when doing transform feedback needs setting to 0 when doing transform feedback
             gl.vertexAttribDivisor(OFFSET_LOCATION, 0);
             gl.vertexAttribDivisor(ROTATION_LOCATION, 0);
-
-            // Set transform feedback buffer
-            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, OFFSET_LOCATION, destinationVBO[OFFSET_LOCATION]);
-            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, ROTATION_LOCATION, destinationVBO[ROTATION_LOCATION]);
 
             // Turn off rasterization - we are not drawing
             gl.enable(gl.RASTERIZER_DISCARD);
@@ -328,7 +331,6 @@
             gl.disable(gl.RASTERIZER_DISCARD);
             gl.useProgram(null);
             gl.bindBuffer(gl.ARRAY_BUFFER, null);
-            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
             gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
 
             // Ping pong the buffers
@@ -369,7 +371,6 @@
 
         // If you have a long-running page, and need to delete WebGL resources, use:
         //
-        // gl.deleteTransformFeedback(transformFeedback);
         // gl.deleteProgram(programs[PROGRAM_TRANSFORM]);
         // gl.deleteProgram(programs[PROGRAM_DRAW]);
         // for (var i = 0; i < 2; ++i) {
@@ -379,9 +380,11 @@
         // }
         // gl.deleteVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
         // gl.deleteVertexArray(vertexArrays[PROGRAM_DRAW]);
+        // gl.deleteTransformFeedback(transformFeedbacks[0]);
+        // gl.deleteTransformFeedback(transformFeedbacks[1]);
     })();
     </script>
-    <div id="highlightedLines"  style="display: none">#L243-L360</div>
+    <div id="highlightedLines"  style="display: none">#L221-L367</div>
 
 </body>
 

--- a/samples/transform_feedback_interleaved.html
+++ b/samples/transform_feedback_interleaved.html
@@ -172,6 +172,14 @@
         gl.bufferData(gl.ARRAY_BUFFER, SIZE_V4C4 * VERTEX_COUNT, gl.STATIC_COPY);
         gl.bindBuffer(gl.ARRAY_BUFFER, null);
 
+        // -- Init TransformFeedback: Track output buffer
+        var transformFeedback = gl.createTransformFeedback();
+        
+        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
+        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, buffers[PROGRAM_FEEDBACK]);
+        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
+
         // -- Init Vertex Array
         var vertexArrays = [gl.createVertexArray(), gl.createVertexArray()];
         gl.bindVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
@@ -191,14 +199,11 @@
         gl.bindBuffer(gl.ARRAY_BUFFER, buffers[PROGRAM_FEEDBACK]);
         gl.vertexAttribPointer(vertexPosLocationFeedback, 4, gl.FLOAT, false, SIZE_V4C4, 0);
         gl.vertexAttribPointer(vertexColorLocationFeedback, 4, gl.FLOAT, false, SIZE_V4C4, SIZE_V4C4 / 2);
-        gl.bindBuffer(gl.ARRAY_BUFFER, null);
         gl.enableVertexAttribArray(vertexPosLocationFeedback);
         gl.enableVertexAttribArray(vertexColorLocationFeedback);
 
+        gl.bindBuffer(gl.ARRAY_BUFFER, null);
         gl.bindVertexArray(null);
-        
-        // -- Init TransformFeedback 
-        var transformFeedback = gl.createTransformFeedback();
 
         // -- Render
         gl.clearColor(0.0, 0.0, 0.0, 1.0);
@@ -208,8 +213,6 @@
         // Disable rasterization, vertices processing only
         gl.enable(gl.RASTERIZER_DISCARD);
         
-        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
-
         gl.useProgram(programs[PROGRAM_TRANSFORM]);
         var matrix = new Float32Array([
             0.5, 0.0, 0.0, 0.0,
@@ -219,15 +222,15 @@
         ]);
         gl.uniformMatrix4fv(mvpLocation, false, matrix);
 
-        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, buffers[PROGRAM_FEEDBACK]);
         gl.bindVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
+        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
 
         gl.beginTransformFeedback(gl.TRIANGLES);
         gl.drawArraysInstanced(gl.TRIANGLES, 0, VERTEX_COUNT, 1);
         gl.endTransformFeedback();
+        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
 
         gl.disable(gl.RASTERIZER_DISCARD);
-        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
 
         // Second draw, reuse captured attributes
         gl.useProgram(programs[PROGRAM_FEEDBACK]);

--- a/samples/transform_feedback_separated.html
+++ b/samples/transform_feedback_separated.html
@@ -186,7 +186,7 @@
         gl.bufferData(gl.ARRAY_BUFFER, positions.length * Float32Array.BYTES_PER_ELEMENT, gl.STATIC_COPY);
         gl.bindBuffer(gl.ARRAY_BUFFER, null);
 
-        // -- Init Vertex Array
+        // -- Init Transform Vertex Array
         var vertexArrays = [gl.createVertexArray(), gl.createVertexArray()];
         gl.bindVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
 
@@ -198,6 +198,16 @@
 
         gl.bindVertexArray(null);
 
+        // -- Init TransformFeedback
+        var transformFeedback = gl.createTransformFeedback();
+        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
+        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, buffers[BufferType.POSITION]);
+        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, buffers[BufferType.COLOR]);
+        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
+        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
+        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, null);
+
+        // -- Init Feedback Vertex Array 
         gl.bindVertexArray(vertexArrays[PROGRAM_FEEDBACK]);
 
         var vertexPosLocationFeedback = 0; // set with GLSL layout qualifier
@@ -213,9 +223,6 @@
         gl.bindBuffer(gl.ARRAY_BUFFER, null);
         gl.bindVertexArray(null);
 
-        // -- Init TransformFeedback
-        var transformFeedback = gl.createTransformFeedback();
-
         // -- Render
 
         gl.clearColor(0.0, 0.0, 0.0, 1.0);
@@ -225,7 +232,6 @@
         // Disable rasterization, vertices processing only
         gl.enable(gl.RASTERIZER_DISCARD);
 
-        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
 
         gl.useProgram(programs[PROGRAM_TRANSFORM]);
         var matrix = new Float32Array([
@@ -236,17 +242,15 @@
         ]);
         gl.uniformMatrix4fv(mvpLocation, false, matrix);
 
-        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, buffers[BufferType.POSITION]);
-        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, buffers[BufferType.COLOR]);
         gl.bindVertexArray(vertexArrays[PROGRAM_TRANSFORM]);
+        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
 
         gl.beginTransformFeedback(gl.TRIANGLES);
         gl.drawArraysInstanced(gl.TRIANGLES, 0, VERTEX_COUNT, 1);
         gl.endTransformFeedback();
+        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, null);
 
         gl.disable(gl.RASTERIZER_DISCARD);
-        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, null);
-        gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, null);
 
         // Second draw, reuse captured attributes
         gl.useProgram(programs[PROGRAM_FEEDBACK]);
@@ -265,7 +269,7 @@
         gl.deleteVertexArray(vertexArrays[PROGRAM_FEEDBACK]);
     })();
     </script>
-    <div id="highlightedLines"  style="display: none">#L108-L255</div>
+    <div id="highlightedLines"  style="display: none">#L108-L251</div>
 
 </body>
 </html>

--- a/samples/transform_feedback_separated_2.html
+++ b/samples/transform_feedback_separated_2.html
@@ -254,6 +254,7 @@
         function render() {
 
             var time = Date.now() - appStartTime;
+            var destinationIdx = (currentSourceIdx + 1) % 2;
 
             // Set the viewport
             gl.viewport(0, 0, canvas.width, canvas.height - 10);
@@ -264,10 +265,18 @@
 
             // Toggle source and destination VBO
             var sourceVAO = particleVAOs[currentSourceIdx];
-            var destinationTransformFeedback = particleTransformFeedbacks[(currentSourceIdx + 1) % 2];
+            var destinationTransformFeedback = particleTransformFeedbacks[destinationIdx];
 
             gl.bindVertexArray(sourceVAO);
             gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, destinationTransformFeedback);
+
+            // NOTE: The following four lines shouldn't be necessary, but are required to work in ANGLE
+            // due to a bug in its handling of transform feedback objects.
+            // https://bugs.chromium.org/p/angleproject/issues/detail?id=2051
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, particleVBOs[destinationIdx][POSITION_LOCATION]);
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, particleVBOs[destinationIdx][VELOCITY_LOCATION]);
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 2, particleVBOs[destinationIdx][SPAWNTIME_LOCATION]);
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 3, particleVBOs[destinationIdx][LIFETIME_LOCATION]);
 
             // Set uniforms
             gl.uniform1f(drawTimeLocation, time);

--- a/samples/transform_feedback_separated_2.html
+++ b/samples/transform_feedback_separated_2.html
@@ -149,11 +149,15 @@
         // -- Init Vertex Arrays and Buffers
         var particleVAOs = [gl.createVertexArray(), gl.createVertexArray()];
 
+        // Transform feedback objects track output buffer state
+        var particleTransformFeedbacks = [gl.createTransformFeedback(), gl.createTransformFeedback()];
+        
         var particleVBOs = new Array(particleVAOs.length);
 
         for (var i = 0; i < particleVAOs.length; ++i) {
             particleVBOs[i] = new Array(NUM_LOCATIONS);
 
+            // Set up input
             gl.bindVertexArray(particleVAOs[i]);
 
             particleVBOs[i][POSITION_LOCATION] = gl.createBuffer();
@@ -185,6 +189,16 @@
             gl.bufferData(gl.ARRAY_BUFFER, particleIDs, gl.STATIC_READ);
             gl.vertexAttribPointer(ID_LOCATION, 1, gl.FLOAT, false, 0, 0);
             gl.enableVertexAttribArray(ID_LOCATION);
+
+            gl.bindBuffer(gl.ARRAY_BUFFER, null);
+            
+            // Set up output
+            gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, particleTransformFeedbacks[i]);
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, particleVBOs[i][POSITION_LOCATION]);
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, particleVBOs[i][VELOCITY_LOCATION]);
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 2, particleVBOs[i][SPAWNTIME_LOCATION]);
+            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 3, particleVBOs[i][LIFETIME_LOCATION]);
+
         }
 
         function initProgram() {
@@ -237,10 +251,6 @@
         gl.enable(gl.BLEND);
         gl.blendFunc(gl.SRC_ALPHA, gl.ONE);
 
-        // -- Init TransformFeedback
-        var transformFeedback = gl.createTransformFeedback();
-        gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, transformFeedback);
-
         function render() {
 
             var time = Date.now() - appStartTime;
@@ -254,15 +264,10 @@
 
             // Toggle source and destination VBO
             var sourceVAO = particleVAOs[currentSourceIdx];
-            var destinationVBO = particleVBOs[(currentSourceIdx + 1) % 2];
+            var destinationTransformFeedback = particleTransformFeedbacks[(currentSourceIdx + 1) % 2];
 
             gl.bindVertexArray(sourceVAO);
-
-            // Set transform feedback buffer
-            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 0, destinationVBO[POSITION_LOCATION]);
-            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 1, destinationVBO[VELOCITY_LOCATION]);
-            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 2, destinationVBO[SPAWNTIME_LOCATION]);
-            gl.bindBufferBase(gl.TRANSFORM_FEEDBACK_BUFFER, 3, destinationVBO[LIFETIME_LOCATION]);
+            gl.bindTransformFeedback(gl.TRANSFORM_FEEDBACK, destinationTransformFeedback);
 
             // Set uniforms
             gl.uniform1f(drawTimeLocation, time);
@@ -282,17 +287,17 @@
 
         // If you have a long-running page, and need to delete WebGL resources, use:
         //
-        // gl.deleteTransformFeedback(transformFeedback);
         // gl.deleteProgram(program);
         // for (var i = 0; i < particleVAOs.length; ++i) {
-        //     gl.deleteVertexArray(i); 
+        //     gl.deleteVertexArray(particleVAOs[i]); 
+        //     gl.deleteTransformFeedback(particleTransformFeedbacks[i]);
         //     for (var j = 0; j < NUM_LOCATIONS; ++j) {
         //         gl.deleteBuffer(particleVBOs[i][j]);
         //     }
         // }
     })();
     </script>
-    <div id="highlightedLines"  style="display: none">#L246-L278</div>
+    <div id="highlightedLines"  style="display: none">#L193-L278</div>
 
 </body>
 


### PR DESCRIPTION
See the wiki entry here: https://www.khronos.org/opengl/wiki/Transform_Feedback#Feedback_objects

Transform feedback objects capture the state of TRANSFORM_FEEDBACK_BUFFER bindings, so when they are set up correctly, you don't have to bind the individual buffers (kind of like an output version of a VAO).

This update moves the setup of transform feedback objects for relevant samples into the parts of the code that set up VAOs, and then simply bind/unbind the transform feedback objects when drawing (rather than binding each individual output buffer).
